### PR TITLE
feat: write-time deduplication for memories

### DIFF
--- a/db/memory.go
+++ b/db/memory.go
@@ -556,6 +556,53 @@ func hasDiagnosticKeywords(query string) bool {
 	return false
 }
 
+// FindSimilar returns the single closest non-archived memory by cosine distance.
+// Returns nil if no memories exist or the closest distance exceeds maxDistance.
+func (c *Client) FindSimilar(embedding []float32, maxDistance float64) (*VectorResult, error) {
+	var m Memory
+	var summary, source, sourceFile, parentID, archivedAt sql.NullString
+	var distance float64
+
+	err := c.DB.QueryRow(`
+		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
+		       m.parent_id, m.chunk_index, m.created_at, m.updated_at, m.archived_at, m.token_count,
+		       vector_distance_cos(m.embedding, vector32(?)) AS distance
+		FROM memories m
+		WHERE m.archived_at IS NULL
+		ORDER BY distance ASC
+		LIMIT 1
+	`, float32sToBytes(embedding)).Scan(
+		&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
+		&source, &sourceFile, &parentID, &m.ChunkIndex,
+		&m.CreatedAt, &m.UpdatedAt, &archivedAt, &m.TokenCount,
+		&distance,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("finding similar memory: %w", err)
+	}
+
+	if distance > maxDistance {
+		return nil, nil
+	}
+
+	m.Summary = summary.String
+	m.Source = source.String
+	m.SourceFile = sourceFile.String
+	m.ParentID = parentID.String
+	m.ArchivedAt = archivedAt.String
+
+	tags, err := c.GetTags(m.ID)
+	if err != nil {
+		return nil, err
+	}
+	m.Tags = tags
+
+	return &VectorResult{Memory: &m, Distance: distance}, nil
+}
+
 func nullString(s string) sql.NullString {
 	if s == "" {
 		return sql.NullString{}

--- a/tools/remember.go
+++ b/tools/remember.go
@@ -4,6 +4,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 
@@ -30,6 +31,7 @@ func (r *Remember) Tool() mcp.Tool {
 		),
 		mcp.WithString("summary", mcp.Description("Brief one-line summary of the memory")),
 		mcp.WithArray("tags", mcp.Description("Tags for categorization"), mcp.WithStringItems()),
+		mcp.WithNumber("dedup_threshold", mcp.Description("Similarity threshold for deduplication (0.0-1.0, default 0.95). Memories above this similarity are considered duplicates.")),
 	)
 }
 
@@ -60,6 +62,28 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError(fmt.Sprintf("generating embedding: %v", err)), nil
 	}
 
+	// Deduplication: check for near-duplicate before inserting
+	dedupThreshold := request.GetFloat("dedup_threshold", 0.95)
+	if dedupThreshold < 0 || dedupThreshold > 1 {
+		dedupThreshold = 0.95
+	}
+	// Convert similarity threshold to cosine distance (distance = 1 - similarity)
+	maxDistance := 1.0 - dedupThreshold
+	// groupDistance is the distance below which we link as parent (similarity 0.85-threshold)
+	groupDistance := 0.15 // 1.0 - 0.85
+
+	match, err := r.DB.FindSimilar(embedding, groupDistance)
+	if err != nil {
+		slog.Warn("dedup check failed, proceeding with insert", "error", err)
+	} else if match != nil && match.Distance <= maxDistance {
+		// Near-duplicate: return existing memory instead of inserting
+		slog.Info("deduplicated memory", "existing_id", match.Memory.ID, "distance", match.Distance)
+		return mcp.NewToolResultText(fmt.Sprintf(
+			"Deduplicated: existing memory %s is %.1f%% similar (project=%s, type=%s). No new memory created.",
+			match.Memory.ID, (1.0-match.Distance)*100, match.Memory.Project, match.Memory.Type,
+		)), nil
+	}
+
 	// Estimate token count (rough: ~4 chars per token)
 	tokenCount := len(content) / 4
 
@@ -71,6 +95,12 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 		Type:       memType,
 		Source:     "claude-code",
 		TokenCount: tokenCount,
+	}
+
+	// Soft-group: link to similar existing memory as parent
+	if match != nil {
+		memory.ParentID = match.Memory.ID
+		slog.Info("linking memory to similar parent", "parent_id", match.Memory.ID, "distance", match.Distance)
 	}
 
 	saved, err := r.DB.SaveMemory(memory)
@@ -85,7 +115,11 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 		}
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Stored memory %s (project=%s, type=%s, tokens=%d)", saved.ID, project, memType, tokenCount)), nil
+	msg := fmt.Sprintf("Stored memory %s (project=%s, type=%s, tokens=%d)", saved.ID, project, memType, tokenCount)
+	if memory.ParentID != "" {
+		msg += fmt.Sprintf(" [linked to similar memory %s, %.1f%% similar]", memory.ParentID, (1.0-match.Distance)*100)
+	}
+	return mcp.NewToolResultText(msg), nil
 }
 
 var secretPatterns = []*regexp.Regexp{

--- a/tools/store_conversation.go
+++ b/tools/store_conversation.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -59,6 +60,21 @@ func (s *StoreConversation) Handle(ctx context.Context, request mcp.CallToolRequ
 		return mcp.NewToolResultError(fmt.Sprintf("generating embedding: %v", err)), nil
 	}
 
+	// Deduplication: check for near-duplicate conversation
+	const dedupDistance = 0.05 // similarity > 0.95
+	const groupDistance = 0.15 // similarity > 0.85
+
+	match, err := s.DB.FindSimilar(embedding, groupDistance)
+	if err != nil {
+		slog.Warn("conversation dedup check failed, proceeding with insert", "error", err)
+	} else if match != nil && match.Distance <= dedupDistance {
+		slog.Info("deduplicated conversation", "existing_id", match.Memory.ID, "distance", match.Distance)
+		return mcp.NewToolResultText(fmt.Sprintf(
+			"Deduplicated: existing conversation %s is %.1f%% similar (channel=%s). No new memory created.",
+			match.Memory.ID, (1.0-match.Distance)*100, channel,
+		)), nil
+	}
+
 	memory := &db.Memory{
 		Content:    content,
 		Summary:    summary,
@@ -67,6 +83,11 @@ func (s *StoreConversation) Handle(ctx context.Context, request mcp.CallToolRequ
 		Visibility: "private",
 		Source:     channel,
 		TokenCount: len(content) / 4,
+	}
+
+	// Soft-group: link to similar existing memory as parent
+	if match != nil {
+		memory.ParentID = match.Memory.ID
 	}
 
 	saved, err := s.DB.SaveMemory(memory)


### PR DESCRIPTION
## Summary
- Adds `FindSimilar()` to db layer — fast top-1 cosine distance lookup against non-archived memories
- Wires dedup check into `remember` and `store_conversation` tool handlers before insert
- **Similarity > 0.95** (distance < 0.05): returns existing memory ID, skips insert
- **Similarity 0.85–0.95** (distance 0.05–0.15): inserts with `parent_id` linking for soft grouping
- **Similarity < 0.85**: normal insert (no change)
- `remember` exposes optional `dedup_threshold` param (default 0.95) for caller control

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] Store a memory, then store near-identical wording — verify dedup message returned
- [ ] Store a moderately similar memory — verify it inserts with `parent_id` set
- [ ] Store a dissimilar memory — verify normal insert with no `parent_id`
- [ ] Pass `dedup_threshold: 0.8` and verify the threshold adjusts accordingly
- [ ] Verify dedup failure (e.g. empty DB) gracefully falls through to normal insert

🤖 Generated with [Claude Code](https://claude.com/claude-code)