### PR TITLE
feat: recency/staleness weighting for search results

### DIFF
--- a/api/conversations.go
+++ b/api/conversations.go
@@ -29,6 +29,7 @@ type conversationSearchRequest struct {
 	Limit        int     `json:"limit"`
 	Channel      string  `json:"channel"`
 	MinRelevance float64 `json:"min_relevance"` // 0.0-1.0, filter by score >= threshold
+	RecencyDecay float64 `json:"recency_decay"` // exponential decay rate (0.0 = disabled, 0.01 recommended)
 }
 
 func (s *Server) handleCreateConversation(w http.ResponseWriter, r *http.Request) {
@@ -187,7 +188,7 @@ func (s *Server) handleSearchConversations(w http.ResponseWriter, r *http.Reques
 		Visibility: "all",
 	}
 
-	resp, err := search.Adaptive(r.Context(), s.db, s.embedder.Embed, req.Query, filter, req.Limit, req.MinRelevance)
+	resp, err := search.Adaptive(r.Context(), s.db, s.embedder.Embed, req.Query, filter, req.Limit, req.MinRelevance, req.RecencyDecay)
 	if err != nil {
 		s.logger.Error("searching conversations", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("search: %v", err)})

--- a/api/recall.go
+++ b/api/recall.go
@@ -12,11 +12,12 @@ import (
 type recallRequest struct {
 	Query        string   `json:"query"`
 	Project      string   `json:"project"`
-	Projects     []string `json:"projects"`     // multi-namespace: any match
+	Projects     []string `json:"projects"`      // multi-namespace: any match
 	Type         string   `json:"type"`
 	Tags         []string `json:"tags"`
 	TopK         int      `json:"top_k"`
-	MinRelevance float64  `json:"min_relevance"` // 0.0-1.0, filter by score >= threshold
+	MinRelevance float64  `json:"min_relevance"`  // 0.0-1.0, filter by score >= threshold
+	RecencyDecay float64  `json:"recency_decay"`  // exponential decay rate (0.0 = disabled, 0.01 recommended)
 }
 
 func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +44,7 @@ func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
 		Visibility: "", // HTTP API: exclude private memories by default
 	}
 
-	resp, err := search.Adaptive(r.Context(), s.db, s.embedder.Embed, req.Query, filter, req.TopK, req.MinRelevance)
+	resp, err := search.Adaptive(r.Context(), s.db, s.embedder.Embed, req.Query, filter, req.TopK, req.MinRelevance, req.RecencyDecay)
 	if err != nil {
 		s.logger.Error("adaptive search", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("search: %v", err)})

--- a/api/search.go
+++ b/api/search.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/claude-memory/search"
 )
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
@@ -22,6 +23,8 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if topK <= 0 {
 		topK = 5
 	}
+
+	recencyDecay, _ := strconv.ParseFloat(q.Get("recency_decay"), 64)
 
 	var tags []string
 	if t := q.Get("tags"); t != "" {
@@ -58,6 +61,8 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
+	search.ApplyRecencyWeighting(results, recencyDecay)
 
 	writeJSON(w, http.StatusOK, results)
 }

--- a/db/memory.go
+++ b/db/memory.go
@@ -51,12 +51,14 @@ type MemoryFilter struct {
 
 // HybridResult wraps a Memory with scores from both retrieval methods.
 type HybridResult struct {
-	Memory    *Memory `json:"memory"`
-	RRFScore  float64 `json:"rrfScore"`  // higher = more relevant
-	VecRank   int     `json:"vecRank"`   // 0 = not in vector results
-	BM25Rank  int     `json:"bm25Rank"`  // 0 = not in BM25 results
-	Distance  float64 `json:"distance"`  // cosine distance (lower = closer)
-	Score     float64 `json:"score"`     // relevance score: 1.0 - distance (higher = more relevant)
+	Memory        *Memory `json:"memory"`
+	RRFScore      float64 `json:"rrfScore"`                // higher = more relevant
+	VecRank       int     `json:"vecRank"`                  // 0 = not in vector results
+	BM25Rank      int     `json:"bm25Rank"`                 // 0 = not in BM25 results
+	Distance      float64 `json:"distance"`                 // cosine distance (lower = closer)
+	Score         float64 `json:"score"`                    // relevance score: 1.0 - distance (higher = more relevant)
+	RecencyWeight float64 `json:"recencyWeight,omitempty"`  // exp(-decay * days_old), 0 if recency weighting disabled
+	WeightedScore float64 `json:"weightedScore,omitempty"` // score * recencyWeight, 0 if disabled
 }
 
 // VectorResult wraps a Memory with its similarity distance.

--- a/search/adaptive.go
+++ b/search/adaptive.go
@@ -24,7 +24,8 @@ type EmbedFunc func(ctx context.Context, text string) ([]float32, error)
 // If no results pass the min_relevance threshold (or zero results are returned),
 // the query is rewritten deterministically and retried once.
 // Set minRelevance to 0 to disable grading (all results pass).
-func Adaptive(ctx context.Context, client *db.Client, embed EmbedFunc, query string, filter *db.MemoryFilter, topK int, minRelevance float64) (*Response, error) {
+// Set recencyDecay > 0 to apply exponential recency weighting (recommended: 0.01).
+func Adaptive(ctx context.Context, client *db.Client, embed EmbedFunc, query string, filter *db.MemoryFilter, topK int, minRelevance float64, recencyDecay float64) (*Response, error) {
 	embedding, err := embed(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("generating embedding: %w", err)
@@ -37,6 +38,7 @@ func Adaptive(ctx context.Context, client *db.Client, embed EmbedFunc, query str
 
 	resolveParents(client, results)
 	filtered := gradeResults(results, minRelevance)
+	ApplyRecencyWeighting(filtered, recencyDecay)
 
 	resp := &Response{
 		Results:  filtered,
@@ -59,7 +61,9 @@ func Adaptive(ctx context.Context, client *db.Client, embed EmbedFunc, query str
 
 			resolveParents(client, results2)
 
-			resp.Results = gradeResults(results2, minRelevance)
+			graded := gradeResults(results2, minRelevance)
+			ApplyRecencyWeighting(graded, recencyDecay)
+			resp.Results = graded
 			resp.Rewritten = true
 			resp.RewrittenQuery = rewritten
 			resp.Attempts = 2

--- a/search/recency.go
+++ b/search/recency.go
@@ -1,0 +1,55 @@
+package search
+
+import (
+	"math"
+	"time"
+
+	"github.com/j33pguy/claude-memory/db"
+)
+
+// ApplyRecencyWeighting multiplies each result's Score by an exponential decay
+// factor based on the memory's age, then re-sorts by WeightedScore descending.
+//
+// recencyWeight = exp(-decayRate * daysSinceCreated)
+// weightedScore = score * recencyWeight
+//
+// A decayRate of 0.01 gives a half-life of ~70 days.
+// If decayRate is <= 0, this is a no-op (backward compat).
+func ApplyRecencyWeighting(results []*db.HybridResult, decayRate float64) {
+	if decayRate <= 0 || len(results) == 0 {
+		return
+	}
+
+	now := time.Now().UTC()
+
+	for _, r := range results {
+		days := daysSince(r.Memory.CreatedAt, now)
+		r.RecencyWeight = math.Exp(-decayRate * days)
+		r.WeightedScore = r.Score * r.RecencyWeight
+	}
+
+	// Re-sort by WeightedScore descending (insertion sort — small slices).
+	for i := 1; i < len(results); i++ {
+		for j := i; j > 0 && results[j].WeightedScore > results[j-1].WeightedScore; j-- {
+			results[j], results[j-1] = results[j-1], results[j]
+		}
+	}
+}
+
+// daysSince returns fractional days between the given RFC3339/DateTime string and now.
+// Returns 0 on parse failure (treat unparseable timestamps as "just created").
+func daysSince(createdAt string, now time.Time) float64 {
+	// Try RFC3339 first, then time.DateTime (used by SQLite datetime('now')).
+	t, err := time.Parse(time.RFC3339, createdAt)
+	if err != nil {
+		t, err = time.Parse(time.DateTime, createdAt)
+		if err != nil {
+			return 0
+		}
+	}
+	d := now.Sub(t)
+	if d < 0 {
+		return 0
+	}
+	return d.Hours() / 24.0
+}

--- a/search/recency_test.go
+++ b/search/recency_test.go
@@ -1,0 +1,88 @@
+package search
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/j33pguy/claude-memory/db"
+)
+
+func TestApplyRecencyWeighting_Disabled(t *testing.T) {
+	results := []*db.HybridResult{
+		{Memory: &db.Memory{CreatedAt: time.Now().UTC().Format(time.RFC3339)}, Score: 0.9},
+		{Memory: &db.Memory{CreatedAt: time.Now().Add(-72 * 24 * time.Hour).UTC().Format(time.RFC3339)}, Score: 0.8},
+	}
+
+	ApplyRecencyWeighting(results, 0.0)
+
+	if results[0].RecencyWeight != 0 || results[0].WeightedScore != 0 {
+		t.Error("expected no weighting when decay=0")
+	}
+}
+
+func TestApplyRecencyWeighting_RecentWins(t *testing.T) {
+	now := time.Now().UTC()
+	results := []*db.HybridResult{
+		{Memory: &db.Memory{CreatedAt: now.Add(-60 * 24 * time.Hour).Format(time.RFC3339)}, Score: 0.9},
+		{Memory: &db.Memory{CreatedAt: now.Add(-1 * 24 * time.Hour).Format(time.RFC3339)}, Score: 0.85},
+	}
+
+	ApplyRecencyWeighting(results, 0.01)
+
+	// The recent memory (0.85 score, 1 day old) should now rank higher
+	// than the old memory (0.9 score, 60 days old) after weighting.
+	if results[0].Score != 0.85 {
+		t.Errorf("expected recent memory first, got score=%f", results[0].Score)
+	}
+	if results[0].WeightedScore <= results[1].WeightedScore {
+		t.Errorf("expected recent memory to have higher weighted score: %f vs %f",
+			results[0].WeightedScore, results[1].WeightedScore)
+	}
+}
+
+func TestApplyRecencyWeighting_HalfLife(t *testing.T) {
+	now := time.Now().UTC()
+	results := []*db.HybridResult{
+		{Memory: &db.Memory{CreatedAt: now.Add(-70 * 24 * time.Hour).Format(time.RFC3339)}, Score: 1.0},
+	}
+
+	ApplyRecencyWeighting(results, 0.01)
+
+	// At ~70 days with decay=0.01, weight should be ~0.5 (half-life).
+	if math.Abs(results[0].RecencyWeight-0.5) > 0.05 {
+		t.Errorf("expected recency weight ~0.5 at 70 days, got %f", results[0].RecencyWeight)
+	}
+}
+
+func TestApplyRecencyWeighting_EmptySlice(t *testing.T) {
+	// Should not panic.
+	ApplyRecencyWeighting(nil, 0.01)
+	ApplyRecencyWeighting([]*db.HybridResult{}, 0.01)
+}
+
+func TestDaysSince(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name      string
+		createdAt string
+		wantDays  float64
+		tolerance float64
+	}{
+		{"RFC3339 now", now.Format(time.RFC3339), 0, 0.01},
+		{"DateTime now", now.Format(time.DateTime), 0, 0.01},
+		{"10 days ago", now.Add(-10 * 24 * time.Hour).Format(time.RFC3339), 10, 0.01},
+		{"unparseable", "garbage", 0, 0},
+		{"future", now.Add(24 * time.Hour).Format(time.RFC3339), 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := daysSince(tt.createdAt, now)
+			if math.Abs(got-tt.wantDays) > tt.tolerance {
+				t.Errorf("daysSince(%q) = %f, want %f (±%f)", tt.createdAt, got, tt.wantDays, tt.tolerance)
+			}
+		})
+	}
+}

--- a/tools/recall.go
+++ b/tools/recall.go
@@ -31,6 +31,7 @@ func (r *Recall) Tool() mcp.Tool {
 		mcp.WithArray("tags", mcp.Description("Filter by tags (any match)"), mcp.WithStringItems()),
 		mcp.WithNumber("top_k", mcp.Description("Number of results to return (default 5)")),
 		mcp.WithNumber("min_relevance", mcp.Description("Minimum relevance score 0.0-1.0 (default 0.0 = no filtering). Results with score below this are excluded. Score = 1.0 - cosine_distance.")),
+		mcp.WithNumber("recency_decay", mcp.Description("Exponential decay rate for recency weighting (default 0.0 = disabled). Recommended: 0.01 (half-life ~70 days). Higher values penalize older memories more.")),
 	)
 }
 
@@ -47,6 +48,7 @@ func (r *Recall) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.
 	tags := request.GetStringSlice("tags", nil)
 	topK := request.GetInt("top_k", 5)
 	minRelevance := request.GetFloat("min_relevance", 0.0)
+	recencyDecay := request.GetFloat("recency_decay", 0.0)
 
 	filter := &db.MemoryFilter{
 		Project:    project,
@@ -56,7 +58,7 @@ func (r *Recall) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.
 		Visibility: "all", // MCP callers (Claude Code, Gilfoyle) see all including private
 	}
 
-	resp, err := search.Adaptive(ctx, r.DB, r.Embedder.Embed, query, filter, topK, minRelevance)
+	resp, err := search.Adaptive(ctx, r.DB, r.Embedder.Embed, query, filter, topK, minRelevance, recencyDecay)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("search: %v", err)), nil
 	}

--- a/tools/recall_conversations.go
+++ b/tools/recall_conversations.go
@@ -25,6 +25,7 @@ func (r *RecallConversations) Tool() mcp.Tool {
 		mcp.WithString("channel", mcp.Description("Filter by conversation channel (e.g. 'discord', 'webchat')")),
 		mcp.WithNumber("top_k", mcp.Description("Number of results to return (default 5)")),
 		mcp.WithNumber("min_relevance", mcp.Description("Minimum relevance score 0.0-1.0 (default 0.0 = no filtering). Results with score below this are excluded.")),
+		mcp.WithNumber("recency_decay", mcp.Description("Exponential decay rate for recency weighting (default 0.0 = disabled). Recommended: 0.01 (half-life ~70 days).")),
 	)
 }
 
@@ -38,6 +39,7 @@ func (r *RecallConversations) Handle(ctx context.Context, request mcp.CallToolRe
 	channel := request.GetString("channel", "")
 	topK := request.GetInt("top_k", 5)
 	minRelevance := request.GetFloat("min_relevance", 0.0)
+	recencyDecay := request.GetFloat("recency_decay", 0.0)
 
 	var tags []string
 	if channel != "" {
@@ -50,7 +52,7 @@ func (r *RecallConversations) Handle(ctx context.Context, request mcp.CallToolRe
 		Visibility: "all",
 	}
 
-	resp, err := search.Adaptive(ctx, r.DB, r.Embedder.Embed, query, filter, topK, minRelevance)
+	resp, err := search.Adaptive(ctx, r.DB, r.Embedder.Embed, query, filter, topK, minRelevance, recencyDecay)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("search: %v", err)), nil
 	}

--- a/tools/recall_incidents.go
+++ b/tools/recall_incidents.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/j33pguy/claude-memory/db"
 	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/claude-memory/search"
 )
 
 // RecallIncidents searches only incident-type memories (things that broke + how they were fixed).
@@ -25,6 +26,7 @@ func (r *RecallIncidents) Tool() mcp.Tool {
 		mcp.WithArray("projects", mcp.Description("Filter by multiple namespaces"), mcp.WithStringItems()),
 		mcp.WithArray("tags", mcp.Description("Filter by tags (any match)"), mcp.WithStringItems()),
 		mcp.WithNumber("top_k", mcp.Description("Number of results to return (default 5)")),
+		mcp.WithNumber("recency_decay", mcp.Description("Exponential decay rate for recency weighting (default 0.0 = disabled). Recommended: 0.01.")),
 	)
 }
 
@@ -39,6 +41,7 @@ func (r *RecallIncidents) Handle(ctx context.Context, request mcp.CallToolReques
 	projects := request.GetStringSlice("projects", nil)
 	tags := request.GetStringSlice("tags", nil)
 	topK := request.GetInt("top_k", 5)
+	recencyDecay := request.GetFloat("recency_decay", 0.0)
 
 	embedding, err := r.Embedder.Embed(ctx, query)
 	if err != nil {
@@ -71,6 +74,8 @@ func (r *RecallIncidents) Handle(ctx context.Context, request mcp.CallToolReques
 			}
 		}
 	}
+
+	search.ApplyRecencyWeighting(results, recencyDecay)
 
 	output, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {

--- a/tools/recall_lessons.go
+++ b/tools/recall_lessons.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/j33pguy/claude-memory/db"
 	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/claude-memory/search"
 )
 
 // RecallLessons searches only lesson-type memories (hard-won knowledge, gotchas).
@@ -25,6 +26,7 @@ func (r *RecallLessons) Tool() mcp.Tool {
 		mcp.WithArray("projects", mcp.Description("Filter by multiple namespaces"), mcp.WithStringItems()),
 		mcp.WithArray("tags", mcp.Description("Filter by tags (any match)"), mcp.WithStringItems()),
 		mcp.WithNumber("top_k", mcp.Description("Number of results to return (default 5)")),
+		mcp.WithNumber("recency_decay", mcp.Description("Exponential decay rate for recency weighting (default 0.0 = disabled). Recommended: 0.01.")),
 	)
 }
 
@@ -39,6 +41,7 @@ func (r *RecallLessons) Handle(ctx context.Context, request mcp.CallToolRequest)
 	projects := request.GetStringSlice("projects", nil)
 	tags := request.GetStringSlice("tags", nil)
 	topK := request.GetInt("top_k", 5)
+	recencyDecay := request.GetFloat("recency_decay", 0.0)
 
 	embedding, err := r.Embedder.Embed(ctx, query)
 	if err != nil {
@@ -71,6 +74,8 @@ func (r *RecallLessons) Handle(ctx context.Context, request mcp.CallToolRequest)
 			}
 		}
 	}
+
+	search.ApplyRecencyWeighting(results, recencyDecay)
 
 	output, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds exponential decay recency weighting to all search/recall endpoints: `weighted_score = score * exp(-decay_rate * days_old)`
- New optional `recency_decay` float param (default 0.0 = disabled, recommended 0.01 = ~70 day half-life)
- Results re-sorted by `weightedScore` when enabled; original `score` preserved for transparency
- Applied post-retrieval in Go (not SQL) across: `recall`, `recall_incidents`, `recall_lessons`, `recall_conversations` MCP tools, `POST /recall`, `GET /search`, `POST /conversations/search` HTTP endpoints

## Test plan
- [x] `go build ./...` passes
- [x] Unit tests for `ApplyRecencyWeighting` and `daysSince` pass (`go test ./search/`)
- [ ] Manual: call `recall` with `recency_decay: 0.01` and verify recent memories rank higher
- [ ] Manual: call with `recency_decay: 0` (or omit) and verify original ranking unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)