### PR TITLE
feat: structured memory taxonomy (speaker, area, sub_area)

### DIFF
--- a/api/memories.go
+++ b/api/memories.go
@@ -30,6 +30,9 @@ func (s *Server) handleListMemories(w http.ResponseWriter, r *http.Request) {
 		Limit:      limit,
 		Offset:     offset,
 		Visibility: "", // HTTP API: exclude private memories by default
+		Speaker:    q.Get("speaker"),
+		Area:       q.Get("area"),
+		SubArea:    q.Get("sub_area"),
 	}
 
 	memories, err := s.db.ListMemories(filter)

--- a/api/recall.go
+++ b/api/recall.go
@@ -18,6 +18,9 @@ type recallRequest struct {
 	TopK         int      `json:"top_k"`
 	MinRelevance float64  `json:"min_relevance"`  // 0.0-1.0, filter by score >= threshold
 	RecencyDecay float64  `json:"recency_decay"`  // exponential decay rate (0.0 = disabled, 0.01 recommended)
+	Speaker      string   `json:"speaker"`
+	Area         string   `json:"area"`
+	SubArea      string   `json:"sub_area"`
 }
 
 func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
@@ -42,6 +45,9 @@ func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
 		Type:       req.Type,
 		Tags:       req.Tags,
 		Visibility: "", // HTTP API: exclude private memories by default
+		Speaker:    req.Speaker,
+		Area:       req.Area,
+		SubArea:    req.SubArea,
 	}
 
 	resp, err := search.Adaptive(r.Context(), s.db, s.embedder.Embed, req.Query, filter, req.TopK, req.MinRelevance, req.RecencyDecay)

--- a/api/remember.go
+++ b/api/remember.go
@@ -17,6 +17,9 @@ type rememberRequest struct {
 	Visibility string   `json:"visibility"`
 	Tags       []string `json:"tags"`
 	Source     string   `json:"source"`
+	Speaker    string   `json:"speaker"`
+	Area       string   `json:"area"`
+	SubArea    string   `json:"sub_area"`
 }
 
 func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
@@ -45,6 +48,11 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	speaker := req.Speaker
+	if speaker == "" {
+		speaker = "gilfoyle"
+	}
+
 	memory := &db.Memory{
 		Content:    req.Content,
 		Summary:    req.Summary,
@@ -53,6 +61,9 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 		Type:       req.Type,
 		Visibility: req.Visibility, // defaults to "internal" in SaveMemory if empty
 		Source:     req.Source,
+		Speaker:    speaker,
+		Area:       req.Area,
+		SubArea:    req.SubArea,
 		TokenCount: len(req.Content) / 4,
 	}
 

--- a/db/memory.go
+++ b/db/memory.go
@@ -19,16 +19,22 @@ type Memory struct {
 	Type       string    `json:"type"`
 	// Visibility controls access: "private" (owner only, never via HTTP API),
 	// "internal" (default, all Claude instances), "public" (any consumer)
-	Visibility string    `json:"visibility"`
-	Source     string    `json:"source"`
-	SourceFile string    `json:"sourceFile"`
-	ParentID   string    `json:"parentId"`
-	ChunkIndex int       `json:"chunkIndex"`
-	CreatedAt  string    `json:"createdAt"`
-	UpdatedAt  string    `json:"updatedAt"`
-	ArchivedAt string    `json:"archivedAt,omitempty"`
-	TokenCount int       `json:"tokenCount"`
-	Tags       []string  `json:"tags,omitempty"`
+	Visibility string `json:"visibility"`
+	Source     string `json:"source"`
+	SourceFile string `json:"sourceFile"`
+	ParentID   string `json:"parentId"`
+	ChunkIndex int    `json:"chunkIndex"`
+	// Speaker is who said/wrote this: j33p, gilfoyle, agent, system
+	Speaker string `json:"speaker,omitempty"`
+	// Area is the top-level domain: work, home, family, homelab, project, meta
+	Area string `json:"area,omitempty"`
+	// SubArea is a free-form sub-domain (power-platform, proxmox, claude-memory, etc.)
+	SubArea   string   `json:"subArea,omitempty"`
+	CreatedAt  string  `json:"createdAt"`
+	UpdatedAt  string  `json:"updatedAt"`
+	ArchivedAt string  `json:"archivedAt,omitempty"`
+	TokenCount int     `json:"tokenCount"`
+	Tags       []string `json:"tags,omitempty"`
 }
 
 // MemoryFilter defines search/filter criteria for listing memories.
@@ -47,6 +53,12 @@ type MemoryFilter struct {
 	// Visibility filters by access level. If empty, defaults to excluding "private"
 	// for HTTP API callers. Set to "all" to include private (MCP/internal use only).
 	Visibility string
+	// Speaker filters by who said/wrote it (j33p, gilfoyle, agent, system).
+	Speaker string
+	// Area filters by top-level domain (work, home, family, homelab, project, meta).
+	Area string
+	// SubArea filters by sub-domain (power-platform, proxmox, claude-memory, etc.).
+	SubArea string
 }
 
 // HybridResult wraps a Memory with scores from both retrieval methods.
@@ -78,8 +90,8 @@ func (c *Client) SaveMemory(m *Memory) (*Memory, error) {
 	}
 
 	err := c.DB.QueryRow(`
-		INSERT INTO memories (content, summary, embedding, project, type, visibility, source, source_file, parent_id, chunk_index, created_at, updated_at, token_count)
-		VALUES (?, ?, vector32(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO memories (content, summary, embedding, project, type, visibility, source, source_file, parent_id, chunk_index, speaker, area, sub_area, created_at, updated_at, token_count)
+		VALUES (?, ?, vector32(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		RETURNING id
 	`,
 		m.Content,
@@ -92,6 +104,9 @@ func (c *Client) SaveMemory(m *Memory) (*Memory, error) {
 		nullString(m.SourceFile),
 		nullString(m.ParentID),
 		m.ChunkIndex,
+		m.Speaker,
+		m.Area,
+		m.SubArea,
 		now,
 		now,
 		m.TokenCount,
@@ -113,11 +128,12 @@ func (c *Client) GetMemory(id string) (*Memory, error) {
 
 	err := c.DB.QueryRow(`
 		SELECT id, content, summary, project, type, visibility, source, source_file, parent_id, chunk_index,
-		       created_at, updated_at, archived_at, token_count
+		       speaker, area, sub_area, created_at, updated_at, archived_at, token_count
 		FROM memories WHERE id = ?
 	`, id).Scan(
 		&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
 		&source, &sourceFile, &parentID, &m.ChunkIndex,
+		&m.Speaker, &m.Area, &m.SubArea,
 		&m.CreatedAt, &m.UpdatedAt, &archivedAt, &m.TokenCount,
 	)
 	if err != nil {
@@ -186,6 +202,7 @@ func (c *Client) ListMemories(filter *MemoryFilter) ([]*Memory, error) {
 	conditions = append(conditions, "m.archived_at IS NULL")
 
 	appendProjectCondition(filter, &conditions, &args)
+	appendTaxonomyConditions(filter, &conditions, &args)
 	if filter.Type != "" {
 		conditions = append(conditions, "m.type = ?")
 		args = append(args, filter.Type)
@@ -210,7 +227,8 @@ func (c *Client) ListMemories(filter *MemoryFilter) ([]*Memory, error) {
 
 	query := fmt.Sprintf(`
 		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
-		       m.parent_id, m.chunk_index, m.created_at, m.updated_at, m.archived_at, m.token_count
+		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
+		       m.created_at, m.updated_at, m.archived_at, m.token_count
 		FROM memories m
 		WHERE %s
 		ORDER BY m.created_at DESC
@@ -240,6 +258,7 @@ func (c *Client) SearchMemories(embedding []float32, filter *MemoryFilter, topK 
 
 	if filter != nil {
 		appendProjectCondition(filter, &conditions, &args)
+		appendTaxonomyConditions(filter, &conditions, &args)
 		if filter.Type != "" {
 			conditions = append(conditions, "m.type = ?")
 			args = append(args, filter.Type)
@@ -265,7 +284,8 @@ func (c *Client) SearchMemories(embedding []float32, filter *MemoryFilter, topK 
 
 	query := fmt.Sprintf(`
 		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
-		       m.parent_id, m.chunk_index, m.created_at, m.updated_at, m.archived_at, m.token_count,
+		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
+		       m.created_at, m.updated_at, m.archived_at, m.token_count,
 		       vector_distance_cos(m.embedding, vector32(?)) AS distance
 		FROM memories m
 		WHERE %s
@@ -288,6 +308,7 @@ func (c *Client) SearchMemories(embedding []float32, filter *MemoryFilter, topK 
 		if err := rows.Scan(
 			&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
 			&source, &sourceFile, &parentID, &m.ChunkIndex,
+			&m.Speaker, &m.Area, &m.SubArea,
 			&m.CreatedAt, &m.UpdatedAt, &archivedAt, &m.TokenCount,
 			&distance,
 		); err != nil {
@@ -324,6 +345,7 @@ func scanMemories(rows *sql.Rows) ([]*Memory, error) {
 		if err := rows.Scan(
 			&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
 			&source, &sourceFile, &parentID, &m.ChunkIndex,
+			&m.Speaker, &m.Area, &m.SubArea,
 			&m.CreatedAt, &m.UpdatedAt, &archivedAt, &m.TokenCount,
 		); err != nil {
 			return nil, fmt.Errorf("scanning memory: %w", err)
@@ -356,6 +378,22 @@ func appendProjectCondition(filter *MemoryFilter, conditions *[]string, args *[]
 	}
 }
 
+// appendTaxonomyConditions adds speaker/area/sub_area filtering to conditions/args.
+func appendTaxonomyConditions(filter *MemoryFilter, conditions *[]string, args *[]any) {
+	if filter.Speaker != "" {
+		*conditions = append(*conditions, "m.speaker = ?")
+		*args = append(*args, filter.Speaker)
+	}
+	if filter.Area != "" {
+		*conditions = append(*conditions, "m.area = ?")
+		*args = append(*args, filter.Area)
+	}
+	if filter.SubArea != "" {
+		*conditions = append(*conditions, "m.sub_area = ?")
+		*args = append(*args, filter.SubArea)
+	}
+}
+
 // appendVisibilityCondition adds visibility filtering to conditions/args.
 func appendVisibilityCondition(filter *MemoryFilter, conditions *[]string, args *[]any) {
 	if filter.Visibility == "all" {
@@ -381,6 +419,7 @@ func (c *Client) SearchMemoriesBM25(query string, filter *MemoryFilter, topK int
 
 	if filter != nil {
 		appendProjectCondition(filter, &conditions, &args)
+		appendTaxonomyConditions(filter, &conditions, &args)
 		if filter.Type != "" {
 			conditions = append(conditions, "m.type = ?")
 			args = append(args, filter.Type)
@@ -395,7 +434,8 @@ func (c *Client) SearchMemoriesBM25(query string, filter *MemoryFilter, topK int
 
 	q := fmt.Sprintf(`
 		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
-		       m.parent_id, m.chunk_index, m.created_at, m.updated_at, m.archived_at, m.token_count,
+		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
+		       m.created_at, m.updated_at, m.archived_at, m.token_count,
 		       -bm25(memories_fts) AS score
 		FROM memories m
 		JOIN memories_fts ON memories_fts.rowid = m.rowid
@@ -419,6 +459,7 @@ func (c *Client) SearchMemoriesBM25(query string, filter *MemoryFilter, topK int
 		if err := rows.Scan(
 			&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
 			&source, &sourceFile, &parentID, &m.ChunkIndex,
+			&m.Speaker, &m.Area, &m.SubArea,
 			&m.CreatedAt, &m.UpdatedAt, &archivedAt, &m.TokenCount,
 			&score,
 		); err != nil {
@@ -567,7 +608,8 @@ func (c *Client) FindSimilar(embedding []float32, maxDistance float64) (*VectorR
 
 	err := c.DB.QueryRow(`
 		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
-		       m.parent_id, m.chunk_index, m.created_at, m.updated_at, m.archived_at, m.token_count,
+		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
+		       m.created_at, m.updated_at, m.archived_at, m.token_count,
 		       vector_distance_cos(m.embedding, vector32(?)) AS distance
 		FROM memories m
 		WHERE m.archived_at IS NULL
@@ -576,6 +618,7 @@ func (c *Client) FindSimilar(embedding []float32, maxDistance float64) (*VectorR
 	`, float32sToBytes(embedding)).Scan(
 		&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
 		&source, &sourceFile, &parentID, &m.ChunkIndex,
+		&m.Speaker, &m.Area, &m.SubArea,
 		&m.CreatedAt, &m.UpdatedAt, &archivedAt, &m.TokenCount,
 		&distance,
 	)

--- a/db/memory_test.go
+++ b/db/memory_test.go
@@ -1,0 +1,109 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestAppendTaxonomyConditions(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         *MemoryFilter
+		wantConditions int
+		wantArgs       int
+	}{
+		{
+			name:           "no taxonomy filters",
+			filter:         &MemoryFilter{},
+			wantConditions: 0,
+			wantArgs:       0,
+		},
+		{
+			name:           "speaker only",
+			filter:         &MemoryFilter{Speaker: "j33p"},
+			wantConditions: 1,
+			wantArgs:       1,
+		},
+		{
+			name:           "area only",
+			filter:         &MemoryFilter{Area: "work"},
+			wantConditions: 1,
+			wantArgs:       1,
+		},
+		{
+			name:           "sub_area only",
+			filter:         &MemoryFilter{SubArea: "proxmox"},
+			wantConditions: 1,
+			wantArgs:       1,
+		},
+		{
+			name:           "all taxonomy fields",
+			filter:         &MemoryFilter{Speaker: "gilfoyle", Area: "homelab", SubArea: "proxmox"},
+			wantConditions: 3,
+			wantArgs:       3,
+		},
+		{
+			name:           "taxonomy with other filters",
+			filter:         &MemoryFilter{Project: "iac", Type: "memory", Speaker: "j33p", Area: "work"},
+			wantConditions: 2, // appendTaxonomyConditions only adds speaker + area
+			wantArgs:       2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var conditions []string
+			var args []any
+
+			appendTaxonomyConditions(tt.filter, &conditions, &args)
+
+			if len(conditions) != tt.wantConditions {
+				t.Errorf("got %d conditions, want %d: %v", len(conditions), tt.wantConditions, conditions)
+			}
+			if len(args) != tt.wantArgs {
+				t.Errorf("got %d args, want %d: %v", len(args), tt.wantArgs, args)
+			}
+		})
+	}
+}
+
+func TestAppendTaxonomyConditions_Values(t *testing.T) {
+	var conditions []string
+	var args []any
+
+	filter := &MemoryFilter{Speaker: "j33p", Area: "homelab", SubArea: "proxmox"}
+	appendTaxonomyConditions(filter, &conditions, &args)
+
+	// Verify correct SQL conditions
+	expected := []string{"m.speaker = ?", "m.area = ?", "m.sub_area = ?"}
+	for i, want := range expected {
+		if conditions[i] != want {
+			t.Errorf("condition[%d] = %q, want %q", i, conditions[i], want)
+		}
+	}
+
+	// Verify correct args
+	expectedArgs := []any{"j33p", "homelab", "proxmox"}
+	for i, want := range expectedArgs {
+		if args[i] != want {
+			t.Errorf("args[%d] = %v, want %v", i, args[i], want)
+		}
+	}
+}
+
+func TestMemoryStructTaxonomyFields(t *testing.T) {
+	m := &Memory{
+		Speaker: "j33p",
+		Area:    "work",
+		SubArea: "power-platform",
+	}
+
+	if m.Speaker != "j33p" {
+		t.Errorf("Speaker = %q, want %q", m.Speaker, "j33p")
+	}
+	if m.Area != "work" {
+		t.Errorf("Area = %q, want %q", m.Area, "work")
+	}
+	if m.SubArea != "power-platform" {
+		t.Errorf("SubArea = %q, want %q", m.SubArea, "power-platform")
+	}
+}

--- a/db/schema.go
+++ b/db/schema.go
@@ -29,6 +29,7 @@ func (s *Schema) run() error {
 		{2, migrationV2},
 		{3, migrationV3},
 		{4, migrationV4},
+		{5, migrationV5},
 	}
 
 	for _, m := range migrations {
@@ -208,6 +209,19 @@ END;
 const migrationV4 = `
 UPDATE memories SET type = 'memory' WHERE type = 'note';
 CREATE INDEX IF NOT EXISTS idx_memories_type_created ON memories(type, created_at DESC);
+`
+
+// migrationV5 adds structured taxonomy fields for categorized recall.
+// speaker: who said/wrote this (j33p, gilfoyle, agent, system)
+// area: top-level domain (work, home, family, homelab, project, meta)
+// sub_area: sub-domain, free-form (power-platform, proxmox, claude-memory, etc.)
+const migrationV5 = `
+ALTER TABLE memories ADD COLUMN speaker TEXT NOT NULL DEFAULT '';
+ALTER TABLE memories ADD COLUMN area TEXT NOT NULL DEFAULT '';
+ALTER TABLE memories ADD COLUMN sub_area TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_memories_speaker ON memories(speaker) WHERE speaker != '';
+CREATE INDEX IF NOT EXISTS idx_memories_area ON memories(area) WHERE area != '';
+CREATE INDEX IF NOT EXISTS idx_memories_area_sub ON memories(area, sub_area) WHERE area != '';
 `
 
 // migrationV2 adds visibility field for access control.

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -57,6 +57,11 @@ func (s *Server) Remember(ctx context.Context, req *pb.RememberRequest) (*pb.Rem
 		return nil, status.Errorf(codes.Internal, "generating embedding: %v", err)
 	}
 
+	speaker := req.Speaker
+	if speaker == "" {
+		speaker = "gilfoyle"
+	}
+
 	memory := &db.Memory{
 		Content:    req.Content,
 		Summary:    req.Summary,
@@ -65,6 +70,9 @@ func (s *Server) Remember(ctx context.Context, req *pb.RememberRequest) (*pb.Rem
 		Type:       memType,
 		Visibility: req.Visibility,
 		Source:     source,
+		Speaker:    speaker,
+		Area:       req.Area,
+		SubArea:    req.SubArea,
 		TokenCount: len(req.Content) / 4,
 	}
 
@@ -74,9 +82,21 @@ func (s *Server) Remember(ctx context.Context, req *pb.RememberRequest) (*pb.Rem
 		return nil, status.Errorf(codes.Internal, "saving memory: %v", err)
 	}
 
+	// Build tags list: user-provided + structured taxonomy tags
+	tags := append([]string{}, req.Tags...)
+	if speaker != "" {
+		tags = append(tags, "speaker:"+speaker)
+	}
+	if req.Area != "" {
+		tags = append(tags, "area:"+req.Area)
+	}
+	if req.SubArea != "" {
+		tags = append(tags, "sub_area:"+req.SubArea)
+	}
+
 	resp := &pb.RememberResponse{Id: saved.ID, Ok: true}
-	if len(req.Tags) > 0 {
-		if err := s.db.SetTags(saved.ID, req.Tags); err != nil {
+	if len(tags) > 0 {
+		if err := s.db.SetTags(saved.ID, tags); err != nil {
 			s.logger.Warn("setting tags failed (non-fatal)", "error", err, "memory_id", saved.ID)
 			tagErr := err.Error()
 			if len(tagErr) > 80 {
@@ -105,6 +125,9 @@ func (s *Server) Recall(ctx context.Context, req *pb.RecallRequest) (*pb.RecallR
 		Type:       req.Type,
 		Tags:       req.Tags,
 		Visibility: "", // gRPC API: exclude private memories by default
+		Speaker:    req.Speaker,
+		Area:       req.Area,
+		SubArea:    req.SubArea,
 	}
 
 	resp, err := search.Adaptive(ctx, s.db, s.embedder.Embed, req.Query, filter, topK, req.MinRelevance, req.RecencyDecay)
@@ -156,6 +179,9 @@ func (s *Server) List(_ context.Context, req *pb.ListRequest) (*pb.ListResponse,
 		Limit:      limit,
 		Offset:     int(req.Offset),
 		Visibility: "", // exclude private by default
+		Speaker:    req.Speaker,
+		Area:       req.Area,
+		SubArea:    req.SubArea,
 	}
 
 	memories, err := s.db.ListMemories(filter)
@@ -279,6 +305,9 @@ func memoryToProto(m *db.Memory) *pb.Memory {
 		UpdatedAt:  m.UpdatedAt,
 		TokenCount: int32(m.TokenCount),
 		Tags:       m.Tags,
+		Speaker:    m.Speaker,
+		Area:       m.Area,
+		SubArea:    m.SubArea,
 	}
 }
 

--- a/proto/memory/v1/memory.pb.go
+++ b/proto/memory/v1/memory.pb.go
@@ -24,21 +24,27 @@ const (
 
 // Memory is the core memory record.
 type Memory struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Content       string                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
-	Summary       string                 `protobuf:"bytes,3,opt,name=summary,proto3" json:"summary,omitempty"`
-	Project       string                 `protobuf:"bytes,4,opt,name=project,proto3" json:"project,omitempty"`
-	Type          string                 `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty"`
-	Visibility    string                 `protobuf:"bytes,6,opt,name=visibility,proto3" json:"visibility,omitempty"`
-	Source        string                 `protobuf:"bytes,7,opt,name=source,proto3" json:"source,omitempty"`
-	SourceFile    string                 `protobuf:"bytes,8,opt,name=source_file,json=sourceFile,proto3" json:"source_file,omitempty"`
-	ParentId      string                 `protobuf:"bytes,9,opt,name=parent_id,json=parentId,proto3" json:"parent_id,omitempty"`
-	ChunkIndex    int32                  `protobuf:"varint,10,opt,name=chunk_index,json=chunkIndex,proto3" json:"chunk_index,omitempty"`
-	CreatedAt     string                 `protobuf:"bytes,11,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt     string                 `protobuf:"bytes,12,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	TokenCount    int32                  `protobuf:"varint,13,opt,name=token_count,json=tokenCount,proto3" json:"token_count,omitempty"`
-	Tags          []string               `protobuf:"bytes,14,rep,name=tags,proto3" json:"tags,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Content    string                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
+	Summary    string                 `protobuf:"bytes,3,opt,name=summary,proto3" json:"summary,omitempty"`
+	Project    string                 `protobuf:"bytes,4,opt,name=project,proto3" json:"project,omitempty"`
+	Type       string                 `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty"`
+	Visibility string                 `protobuf:"bytes,6,opt,name=visibility,proto3" json:"visibility,omitempty"`
+	Source     string                 `protobuf:"bytes,7,opt,name=source,proto3" json:"source,omitempty"`
+	SourceFile string                 `protobuf:"bytes,8,opt,name=source_file,json=sourceFile,proto3" json:"source_file,omitempty"`
+	ParentId   string                 `protobuf:"bytes,9,opt,name=parent_id,json=parentId,proto3" json:"parent_id,omitempty"`
+	ChunkIndex int32                  `protobuf:"varint,10,opt,name=chunk_index,json=chunkIndex,proto3" json:"chunk_index,omitempty"`
+	CreatedAt  string                 `protobuf:"bytes,11,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt  string                 `protobuf:"bytes,12,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	TokenCount int32                  `protobuf:"varint,13,opt,name=token_count,json=tokenCount,proto3" json:"token_count,omitempty"`
+	Tags       []string               `protobuf:"bytes,14,rep,name=tags,proto3" json:"tags,omitempty"`
+	// Taxonomy: who said/wrote this (j33p, gilfoyle, agent, system)
+	Speaker string `protobuf:"bytes,15,opt,name=speaker,proto3" json:"speaker,omitempty"`
+	// Taxonomy: top-level domain (work, home, family, homelab, project, meta)
+	Area string `protobuf:"bytes,16,opt,name=area,proto3" json:"area,omitempty"`
+	// Taxonomy: sub-domain, free-form (power-platform, proxmox, claude-memory, etc.)
+	SubArea       string `protobuf:"bytes,17,opt,name=sub_area,json=subArea,proto3" json:"sub_area,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -171,6 +177,27 @@ func (x *Memory) GetTags() []string {
 	return nil
 }
 
+func (x *Memory) GetSpeaker() string {
+	if x != nil {
+		return x.Speaker
+	}
+	return ""
+}
+
+func (x *Memory) GetArea() string {
+	if x != nil {
+		return x.Area
+	}
+	return ""
+}
+
+func (x *Memory) GetSubArea() string {
+	if x != nil {
+		return x.SubArea
+	}
+	return ""
+}
+
 // MemoryResult wraps a Memory with relevance scores from hybrid search.
 type MemoryResult struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -282,6 +309,9 @@ type RememberRequest struct {
 	Visibility    string                 `protobuf:"bytes,5,opt,name=visibility,proto3" json:"visibility,omitempty"`
 	Tags          []string               `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	Source        string                 `protobuf:"bytes,7,opt,name=source,proto3" json:"source,omitempty"`
+	Speaker       string                 `protobuf:"bytes,8,opt,name=speaker,proto3" json:"speaker,omitempty"`                 // j33p, gilfoyle, agent, system
+	Area          string                 `protobuf:"bytes,9,opt,name=area,proto3" json:"area,omitempty"`                       // work, home, family, homelab, project, meta
+	SubArea       string                 `protobuf:"bytes,10,opt,name=sub_area,json=subArea,proto3" json:"sub_area,omitempty"` // free-form sub-domain
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -365,6 +395,27 @@ func (x *RememberRequest) GetSource() string {
 	return ""
 }
 
+func (x *RememberRequest) GetSpeaker() string {
+	if x != nil {
+		return x.Speaker
+	}
+	return ""
+}
+
+func (x *RememberRequest) GetArea() string {
+	if x != nil {
+		return x.Area
+	}
+	return ""
+}
+
+func (x *RememberRequest) GetSubArea() string {
+	if x != nil {
+		return x.SubArea
+	}
+	return ""
+}
+
 type RememberResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -436,6 +487,9 @@ type RecallRequest struct {
 	TopK          int32                  `protobuf:"varint,6,opt,name=top_k,json=topK,proto3" json:"top_k,omitempty"`
 	MinRelevance  float64                `protobuf:"fixed64,7,opt,name=min_relevance,json=minRelevance,proto3" json:"min_relevance,omitempty"`
 	RecencyDecay  float64                `protobuf:"fixed64,8,opt,name=recency_decay,json=recencyDecay,proto3" json:"recency_decay,omitempty"`
+	Speaker       string                 `protobuf:"bytes,9,opt,name=speaker,proto3" json:"speaker,omitempty"`
+	Area          string                 `protobuf:"bytes,10,opt,name=area,proto3" json:"area,omitempty"`
+	SubArea       string                 `protobuf:"bytes,11,opt,name=sub_area,json=subArea,proto3" json:"sub_area,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -524,6 +578,27 @@ func (x *RecallRequest) GetRecencyDecay() float64 {
 		return x.RecencyDecay
 	}
 	return 0
+}
+
+func (x *RecallRequest) GetSpeaker() string {
+	if x != nil {
+		return x.Speaker
+	}
+	return ""
+}
+
+func (x *RecallRequest) GetArea() string {
+	if x != nil {
+		return x.Area
+	}
+	return ""
+}
+
+func (x *RecallRequest) GetSubArea() string {
+	if x != nil {
+		return x.SubArea
+	}
+	return ""
 }
 
 type RecallResponse struct {
@@ -699,6 +774,9 @@ type ListRequest struct {
 	Project       string                 `protobuf:"bytes,3,opt,name=project,proto3" json:"project,omitempty"`
 	Type          string                 `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
 	Tags          string                 `protobuf:"bytes,5,opt,name=tags,proto3" json:"tags,omitempty"` // comma-separated for HTTP GET query param compat
+	Speaker       string                 `protobuf:"bytes,6,opt,name=speaker,proto3" json:"speaker,omitempty"`
+	Area          string                 `protobuf:"bytes,7,opt,name=area,proto3" json:"area,omitempty"`
+	SubArea       string                 `protobuf:"bytes,8,opt,name=sub_area,json=subArea,proto3" json:"sub_area,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -764,6 +842,27 @@ func (x *ListRequest) GetType() string {
 func (x *ListRequest) GetTags() string {
 	if x != nil {
 		return x.Tags
+	}
+	return ""
+}
+
+func (x *ListRequest) GetSpeaker() string {
+	if x != nil {
+		return x.Speaker
+	}
+	return ""
+}
+
+func (x *ListRequest) GetArea() string {
+	if x != nil {
+		return x.Area
+	}
+	return ""
+}
+
+func (x *ListRequest) GetSubArea() string {
+	if x != nil {
+		return x.SubArea
 	}
 	return ""
 }
@@ -1219,7 +1318,7 @@ var File_memory_v1_memory_proto protoreflect.FileDescriptor
 
 const file_memory_v1_memory_proto_rawDesc = "" +
 	"\n" +
-	"\x16memory/v1/memory.proto\x12\tmemory.v1\x1a\x1cgoogle/api/annotations.proto\"\x84\x03\n" +
+	"\x16memory/v1/memory.proto\x12\tmemory.v1\x1a\x1cgoogle/api/annotations.proto\"\xcd\x03\n" +
 	"\x06Memory\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\acontent\x18\x02 \x01(\tR\acontent\x12\x18\n" +
@@ -1242,7 +1341,10 @@ const file_memory_v1_memory_proto_rawDesc = "" +
 	"updated_at\x18\f \x01(\tR\tupdatedAt\x12\x1f\n" +
 	"\vtoken_count\x18\r \x01(\x05R\n" +
 	"tokenCount\x12\x12\n" +
-	"\x04tags\x18\x0e \x03(\tR\x04tags\"\x8e\x02\n" +
+	"\x04tags\x18\x0e \x03(\tR\x04tags\x12\x18\n" +
+	"\aspeaker\x18\x0f \x01(\tR\aspeaker\x12\x12\n" +
+	"\x04area\x18\x10 \x01(\tR\x04area\x12\x19\n" +
+	"\bsub_area\x18\x11 \x01(\tR\asubArea\"\x8e\x02\n" +
 	"\fMemoryResult\x12)\n" +
 	"\x06memory\x18\x01 \x01(\v2\x11.memory.v1.MemoryR\x06memory\x12\x1b\n" +
 	"\trrf_score\x18\x02 \x01(\x01R\brrfScore\x12\x19\n" +
@@ -1251,7 +1353,7 @@ const file_memory_v1_memory_proto_rawDesc = "" +
 	"\bdistance\x18\x05 \x01(\x01R\bdistance\x12\x14\n" +
 	"\x05score\x18\x06 \x01(\x01R\x05score\x12%\n" +
 	"\x0erecency_weight\x18\a \x01(\x01R\rrecencyWeight\x12%\n" +
-	"\x0eweighted_score\x18\b \x01(\x01R\rweightedScore\"\xbf\x01\n" +
+	"\x0eweighted_score\x18\b \x01(\x01R\rweightedScore\"\x88\x02\n" +
 	"\x0fRememberRequest\x12\x18\n" +
 	"\acontent\x18\x01 \x01(\tR\acontent\x12\x18\n" +
 	"\asummary\x18\x02 \x01(\tR\asummary\x12\x18\n" +
@@ -1261,12 +1363,16 @@ const file_memory_v1_memory_proto_rawDesc = "" +
 	"visibility\x18\x05 \x01(\tR\n" +
 	"visibility\x12\x12\n" +
 	"\x04tags\x18\x06 \x03(\tR\x04tags\x12\x16\n" +
-	"\x06source\x18\a \x01(\tR\x06source\"S\n" +
+	"\x06source\x18\a \x01(\tR\x06source\x12\x18\n" +
+	"\aspeaker\x18\b \x01(\tR\aspeaker\x12\x12\n" +
+	"\x04area\x18\t \x01(\tR\x04area\x12\x19\n" +
+	"\bsub_area\x18\n" +
+	" \x01(\tR\asubArea\"S\n" +
 	"\x10RememberResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x0e\n" +
 	"\x02ok\x18\x02 \x01(\bR\x02ok\x12\x1f\n" +
 	"\vtag_warning\x18\x03 \x01(\tR\n" +
-	"tagWarning\"\xe2\x01\n" +
+	"tagWarning\"\xab\x02\n" +
 	"\rRecallRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x18\n" +
 	"\aproject\x18\x02 \x01(\tR\aproject\x12\x1a\n" +
@@ -1275,7 +1381,11 @@ const file_memory_v1_memory_proto_rawDesc = "" +
 	"\x04tags\x18\x05 \x03(\tR\x04tags\x12\x13\n" +
 	"\x05top_k\x18\x06 \x01(\x05R\x04topK\x12#\n" +
 	"\rmin_relevance\x18\a \x01(\x01R\fminRelevance\x12#\n" +
-	"\rrecency_decay\x18\b \x01(\x01R\frecencyDecay\"\xa6\x01\n" +
+	"\rrecency_decay\x18\b \x01(\x01R\frecencyDecay\x12\x18\n" +
+	"\aspeaker\x18\t \x01(\tR\aspeaker\x12\x12\n" +
+	"\x04area\x18\n" +
+	" \x01(\tR\x04area\x12\x19\n" +
+	"\bsub_area\x18\v \x01(\tR\asubArea\"\xa6\x01\n" +
 	"\x0eRecallResponse\x121\n" +
 	"\aresults\x18\x01 \x03(\v2\x17.memory.v1.MemoryResultR\aresults\x12\x1c\n" +
 	"\trewritten\x18\x02 \x01(\bR\trewritten\x12'\n" +
@@ -1285,13 +1395,16 @@ const file_memory_v1_memory_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"0\n" +
 	"\x0eForgetResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x0e\n" +
-	"\x02ok\x18\x02 \x01(\bR\x02ok\"}\n" +
+	"\x02ok\x18\x02 \x01(\bR\x02ok\"\xc6\x01\n" +
 	"\vListRequest\x12\x14\n" +
 	"\x05limit\x18\x01 \x01(\x05R\x05limit\x12\x16\n" +
 	"\x06offset\x18\x02 \x01(\x05R\x06offset\x12\x18\n" +
 	"\aproject\x18\x03 \x01(\tR\aproject\x12\x12\n" +
 	"\x04type\x18\x04 \x01(\tR\x04type\x12\x12\n" +
-	"\x04tags\x18\x05 \x01(\tR\x04tags\"=\n" +
+	"\x04tags\x18\x05 \x01(\tR\x04tags\x12\x18\n" +
+	"\aspeaker\x18\x06 \x01(\tR\aspeaker\x12\x12\n" +
+	"\x04area\x18\a \x01(\tR\x04area\x12\x19\n" +
+	"\bsub_area\x18\b \x01(\tR\asubArea\"=\n" +
 	"\fListResponse\x12-\n" +
 	"\bmemories\x18\x01 \x03(\v2\x11.memory.v1.MemoryR\bmemories\"\x0f\n" +
 	"\rHealthRequest\":\n" +

--- a/proto/memory/v1/memory.proto
+++ b/proto/memory/v1/memory.proto
@@ -62,6 +62,12 @@ message Memory {
   string updated_at = 12;
   int32 token_count = 13;
   repeated string tags = 14;
+  // Taxonomy: who said/wrote this (j33p, gilfoyle, agent, system)
+  string speaker = 15;
+  // Taxonomy: top-level domain (work, home, family, homelab, project, meta)
+  string area = 16;
+  // Taxonomy: sub-domain, free-form (power-platform, proxmox, claude-memory, etc.)
+  string sub_area = 17;
 }
 
 // MemoryResult wraps a Memory with relevance scores from hybrid search.
@@ -85,6 +91,9 @@ message RememberRequest {
   string visibility = 5;
   repeated string tags = 6;
   string source = 7;
+  string speaker = 8;  // j33p, gilfoyle, agent, system
+  string area = 9;     // work, home, family, homelab, project, meta
+  string sub_area = 10; // free-form sub-domain
 }
 
 message RememberResponse {
@@ -103,6 +112,9 @@ message RecallRequest {
   int32 top_k = 6;
   double min_relevance = 7;
   double recency_decay = 8;
+  string speaker = 9;
+  string area = 10;
+  string sub_area = 11;
 }
 
 message RecallResponse {
@@ -129,6 +141,9 @@ message ListRequest {
   string project = 3;
   string type = 4;
   string tags = 5; // comma-separated for HTTP GET query param compat
+  string speaker = 6;
+  string area = 7;
+  string sub_area = 8;
 }
 
 message ListResponse {

--- a/tools/list.go
+++ b/tools/list.go
@@ -26,6 +26,15 @@ func (l *List) Tool() mcp.Tool {
 		mcp.WithArray("tags", mcp.Description("Filter by tags"), mcp.WithStringItems()),
 		mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
 		mcp.WithNumber("offset", mcp.Description("Pagination offset (default 0)")),
+		mcp.WithString("speaker",
+			mcp.Description("Filter by speaker: j33p, gilfoyle, agent, system"),
+			mcp.Enum("j33p", "gilfoyle", "agent", "system"),
+		),
+		mcp.WithString("area",
+			mcp.Description("Filter by area: work, home, family, homelab, project, meta"),
+			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
+		),
+		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, claude-memory)")),
 	)
 }
 
@@ -37,6 +46,9 @@ func (l *List) Handle(_ context.Context, request mcp.CallToolRequest) (*mcp.Call
 		Tags:    request.GetStringSlice("tags", nil),
 		Limit:   request.GetInt("limit", 20),
 		Offset:  request.GetInt("offset", 0),
+		Speaker: request.GetString("speaker", ""),
+		Area:    request.GetString("area", ""),
+		SubArea: request.GetString("sub_area", ""),
 	}
 
 	memories, err := l.DB.ListMemories(filter)

--- a/tools/recall.go
+++ b/tools/recall.go
@@ -32,6 +32,15 @@ func (r *Recall) Tool() mcp.Tool {
 		mcp.WithNumber("top_k", mcp.Description("Number of results to return (default 5)")),
 		mcp.WithNumber("min_relevance", mcp.Description("Minimum relevance score 0.0-1.0 (default 0.0 = no filtering). Results with score below this are excluded. Score = 1.0 - cosine_distance.")),
 		mcp.WithNumber("recency_decay", mcp.Description("Exponential decay rate for recency weighting (default 0.0 = disabled). Recommended: 0.01 (half-life ~70 days). Higher values penalize older memories more.")),
+		mcp.WithString("speaker",
+			mcp.Description("Filter by speaker: j33p, gilfoyle, agent, system"),
+			mcp.Enum("j33p", "gilfoyle", "agent", "system"),
+		),
+		mcp.WithString("area",
+			mcp.Description("Filter by area: work, home, family, homelab, project, meta"),
+			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
+		),
+		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, claude-memory)")),
 	)
 }
 
@@ -49,6 +58,9 @@ func (r *Recall) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.
 	topK := request.GetInt("top_k", 5)
 	minRelevance := request.GetFloat("min_relevance", 0.0)
 	recencyDecay := request.GetFloat("recency_decay", 0.0)
+	speaker := request.GetString("speaker", "")
+	area := request.GetString("area", "")
+	subArea := request.GetString("sub_area", "")
 
 	filter := &db.MemoryFilter{
 		Project:    project,
@@ -56,6 +68,9 @@ func (r *Recall) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.
 		Type:       memType,
 		Tags:       tags,
 		Visibility: "all", // MCP callers (Claude Code, Gilfoyle) see all including private
+		Speaker:    speaker,
+		Area:       area,
+		SubArea:    subArea,
 	}
 
 	resp, err := search.Adaptive(ctx, r.DB, r.Embedder.Embed, query, filter, topK, minRelevance, recencyDecay)

--- a/tools/remember.go
+++ b/tools/remember.go
@@ -32,6 +32,17 @@ func (r *Remember) Tool() mcp.Tool {
 		mcp.WithString("summary", mcp.Description("Brief one-line summary of the memory")),
 		mcp.WithArray("tags", mcp.Description("Tags for categorization"), mcp.WithStringItems()),
 		mcp.WithNumber("dedup_threshold", mcp.Description("Similarity threshold for deduplication (0.0-1.0, default 0.95). Memories above this similarity are considered duplicates.")),
+		mcp.WithString("speaker",
+			mcp.Description("Who said/wrote this. Default: gilfoyle"),
+			mcp.Enum("j33p", "gilfoyle", "agent", "system"),
+		),
+		mcp.WithString("area",
+			mcp.Description("Top-level life/work domain"),
+			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
+		),
+		mcp.WithString("sub_area",
+			mcp.Description("Sub-domain within area. Examples — work: power-platform, fabric, power-bi, sharepoint, teams, azure, td-synnex; homelab: proxmox, networking, security, dns, monitoring, storage, iac, vault, traefik, authentik, lancache; project: claude-memory, distify, labctl, vault-unsealer, iac; home: lego, gaming, streaming, media; family: kids, spouse, schedule"),
+		),
 	)
 }
 
@@ -50,6 +61,9 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 	memType := request.GetString("type", "memory")
 	summary := request.GetString("summary", "")
 	tags := request.GetStringSlice("tags", nil)
+	speaker := request.GetString("speaker", "gilfoyle")
+	area := request.GetString("area", "")
+	subArea := request.GetString("sub_area", "")
 
 	// Check for potential secrets
 	if warning := detectSecrets(content); warning != "" {
@@ -94,6 +108,9 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 		Project:    project,
 		Type:       memType,
 		Source:     "claude-code",
+		Speaker:    speaker,
+		Area:       area,
+		SubArea:    subArea,
 		TokenCount: tokenCount,
 	}
 
@@ -106,6 +123,17 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 	saved, err := r.DB.SaveMemory(memory)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("saving memory: %v", err)), nil
+	}
+
+	// Append structured taxonomy tags
+	if speaker != "" {
+		tags = append(tags, "speaker:"+speaker)
+	}
+	if area != "" {
+		tags = append(tags, "area:"+area)
+	}
+	if subArea != "" {
+		tags = append(tags, "sub_area:"+subArea)
 	}
 
 	// Set tags


### PR DESCRIPTION
## Summary
- Adds `speaker`, `area`, and `sub_area` columns to the memories table for structured categorization
- Enables filtering by WHO said something (`j33p`, `gilfoyle`, `agent`, `system`), WHAT AREA (`work`, `home`, `family`, `homelab`, `project`, `meta`), and SUB_AREA (free-form: `power-platform`, `proxmox`, `claude-memory`, etc.)
- All new params are optional — fully backward compatible with existing MCP tools, gRPC, and HTTP API
- Auto-writes structured tags (`speaker:X`, `area:Y`, `sub_area:Z`) for backward compat with tag-based search

## Changes
- **DB**: Migration V5 adds 3 columns + partial indexes
- **db package**: Memory struct, MemoryFilter, all queries (INSERT/SELECT/search) updated
- **MCP tools**: `remember`, `recall`, `list_memories` accept new optional params
- **Proto + gRPC**: New fields on `Memory`, `RememberRequest`, `RecallRequest`, `ListRequest`
- **Legacy HTTP API**: taxonomy support in remember/recall/list endpoints
- **Tests**: Unit tests for taxonomy condition builder

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [ ] Manual test: remember with speaker/area/sub_area, verify tags auto-written
- [ ] Manual test: recall/list with taxonomy filters, verify filtering works
- [ ] Verify migration runs cleanly on existing database

🤖 Generated with [Claude Code](https://claude.com/claude-code)