### PR TITLE
feat: auto-classify memories by content heuristics

### DIFF
--- a/classify/classify.go
+++ b/classify/classify.go
@@ -1,0 +1,67 @@
+// Package classify provides heuristic content classification for memories.
+package classify
+
+import "regexp"
+
+// Classification holds inferred taxonomy fields.
+type Classification struct {
+	Speaker string
+	Area    string
+	SubArea string
+}
+
+type rule struct {
+	pattern *regexp.Regexp
+	area    string
+	subArea string
+}
+
+var rules = []rule{
+	// work
+	{regexp.MustCompile(`(?i)power.?platform|power bi|power automate|power apps`), "work", "power-platform"},
+	{regexp.MustCompile(`(?i)microsoft fabric|fabric capacity|fabric workspace`), "work", "fabric"},
+	{regexp.MustCompile(`(?i)power.?bi|pbix|\bdax\b|\bdashboard\b|\breport\b`), "work", "power-bi"},
+	{regexp.MustCompile(`(?i)sharepoint|spo\b`), "work", "sharepoint"},
+	{regexp.MustCompile(`(?i)td.?synnex|synnex|partner enablement|solutions architect`), "work", "td-synnex"},
+	{regexp.MustCompile(`(?i)azure|microsoft 365|m365|\bteams\b|entra`), "work", "azure"},
+
+	// project (before homelab — more specific patterns like vault-unsealer must match before generic vault)
+	{regexp.MustCompile(`(?i)claude.?memory|memory server|mcp server`), "project", "claude-memory"},
+	{regexp.MustCompile(`(?i)distify|behavioral trust|trust verification`), "project", "distify"},
+	{regexp.MustCompile(`(?i)labctl|lab.?ctl`), "project", "labctl"},
+	{regexp.MustCompile(`(?i)vault.?unsealer|auto.?unseal`), "project", "vault-unsealer"},
+
+	// homelab (ansible/terraform before proxmox — "ansible playbook to configure LXC" should match iac, not proxmox)
+	{regexp.MustCompile(`(?i)ansible|playbook|\brole\b|inventory|semaphore`), "homelab", "iac"},
+	{regexp.MustCompile(`(?i)terraform|tfstate`), "homelab", "iac"},
+	{regexp.MustCompile(`(?i)proxmox|pve|lxc container|\bvm\b|qemu|ct\d+`), "homelab", "proxmox"},
+	{regexp.MustCompile(`(?i)pihole|pi-hole|\bdns\b|unbound|blocklist`), "homelab", "dns"},
+	{regexp.MustCompile(`(?i)traefik|reverse proxy|let.?s encrypt|acme|\bcertificate\b`), "homelab", "networking"},
+	{regexp.MustCompile(`(?i)\bvault\b|hashicorp|approle|\bsecret\b`), "homelab", "vault"},
+	{regexp.MustCompile(`(?i)authentik|oidc|\bsso\b|forward.?auth|webauthn|yubikey`), "homelab", "authentik"},
+	{regexp.MustCompile(`(?i)grafana|prometheus|loki|alertmanager|monitoring`), "homelab", "monitoring"},
+	{regexp.MustCompile(`(?i)lancache|steam.?cache|cdn.?cache`), "homelab", "lancache"},
+	{regexp.MustCompile(`(?i)\bvlan\b|\bswitch\b|ubiquiti|unifi|\bnetwork\b`), "homelab", "networking"},
+
+	// home
+	{regexp.MustCompile(`(?i)lego|technic|minifig|\bmoc\b|set \d{4,}`), "home", "lego"},
+	{regexp.MustCompile(`(?i)twitch|streaming|\bobs\b|ring light`), "home", "streaming"},
+	{regexp.MustCompile(`(?i)youtube|j33pguy`), "home", "streaming"},
+	{regexp.MustCompile(`(?i)stationeers|gaming|\bgame\b`), "home", "gaming"},
+
+	// family
+	{regexp.MustCompile(`(?i)\bkids?\b|\bboys?\b|\bson\b|\bdaughter\b|school|sports`), "family", "kids"},
+	{regexp.MustCompile(`(?i)wife|spouse|\bpartner\b`), "family", "spouse"},
+}
+
+// Infer returns a best-guess Classification for the given content.
+// Returns empty strings for fields it cannot determine.
+// Speaker is always left empty — callers should set it explicitly.
+func Infer(content string) Classification {
+	for _, r := range rules {
+		if r.pattern.MatchString(content) {
+			return Classification{Area: r.area, SubArea: r.subArea}
+		}
+	}
+	return Classification{}
+}

--- a/classify/classify_test.go
+++ b/classify/classify_test.go
@@ -1,0 +1,130 @@
+package classify
+
+import "testing"
+
+func TestInfer(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		area    string
+		subArea string
+	}{
+		{
+			name:    "traefik reverse proxy",
+			content: "Set up Traefik reverse proxy with Let's Encrypt",
+			area:    "homelab",
+			subArea: "networking",
+		},
+		{
+			name:    "td synnex power platform",
+			content: "Power Platform solution architect meeting at TD SYNNEX",
+			area:    "work",
+			subArea: "power-platform",
+		},
+		{
+			name:    "lego technic with kids",
+			content: "Built the LEGO Technic tractor set with the boys",
+			area:    "home",
+			subArea: "lego",
+		},
+		{
+			name:    "proxmox lxc containers",
+			content: "Proxmox node pve-01 running LXC containers for all services",
+			area:    "homelab",
+			subArea: "proxmox",
+		},
+		{
+			name:    "fabric workspace",
+			content: "Created a new Microsoft Fabric workspace for the analytics team",
+			area:    "work",
+			subArea: "fabric",
+		},
+		{
+			name:    "pihole dns",
+			content: "Updated Pi-hole blocklist and restarted unbound resolver",
+			area:    "homelab",
+			subArea: "dns",
+		},
+		{
+			name:    "claude-memory project",
+			content: "Refactored claude-memory MCP server to use gRPC transport",
+			area:    "project",
+			subArea: "claude-memory",
+		},
+		{
+			name:    "vault unsealer",
+			content: "Deployed the vault-unsealer service for auto-unseal on boot",
+			area:    "project",
+			subArea: "vault-unsealer",
+		},
+		{
+			name:    "grafana monitoring",
+			content: "Set up Grafana dashboards with Prometheus metrics for homelab",
+			area:    "homelab",
+			subArea: "monitoring",
+		},
+		{
+			name:    "sharepoint work",
+			content: "Migrated team site from SharePoint on-prem to SPO",
+			area:    "work",
+			subArea: "sharepoint",
+		},
+		{
+			name:    "ansible iac",
+			content: "Wrote Ansible playbook to configure all LXC containers",
+			area:    "homelab",
+			subArea: "iac",
+		},
+		{
+			name:    "gaming stationeers",
+			content: "Playing Stationeers on the dedicated game server",
+			area:    "home",
+			subArea: "gaming",
+		},
+		{
+			name:    "authentik sso",
+			content: "Configured Authentik OIDC provider for SSO across all services",
+			area:    "homelab",
+			subArea: "authentik",
+		},
+		{
+			name:    "distify project",
+			content: "Working on distify behavioral trust verification module",
+			area:    "project",
+			subArea: "distify",
+		},
+		{
+			name:    "family kids school",
+			content: "Picked up the kids from school and drove to sports practice",
+			area:    "family",
+			subArea: "kids",
+		},
+		{
+			name:    "lancache steam",
+			content: "lancache pre-cached the latest Steam updates overnight",
+			area:    "homelab",
+			subArea: "lancache",
+		},
+		{
+			name:    "no match returns empty",
+			content: "Just a random thought about nothing in particular",
+			area:    "",
+			subArea: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Infer(tt.content)
+			if got.Area != tt.area {
+				t.Errorf("area: got %q, want %q", got.Area, tt.area)
+			}
+			if got.SubArea != tt.subArea {
+				t.Errorf("sub_area: got %q, want %q", got.SubArea, tt.subArea)
+			}
+			if got.Speaker != "" {
+				t.Errorf("speaker: got %q, want empty", got.Speaker)
+			}
+		})
+	}
+}

--- a/tools/remember.go
+++ b/tools/remember.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/j33pguy/claude-memory/classify"
 	"github.com/j33pguy/claude-memory/db"
 	"github.com/j33pguy/claude-memory/embeddings"
 )
@@ -64,6 +65,17 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 	speaker := request.GetString("speaker", "gilfoyle")
 	area := request.GetString("area", "")
 	subArea := request.GetString("sub_area", "")
+
+	// Auto-classify if not explicitly set
+	if area == "" || subArea == "" {
+		c := classify.Infer(content)
+		if area == "" {
+			area = c.Area
+		}
+		if subArea == "" {
+			subArea = c.SubArea
+		}
+	}
 
 	// Check for potential secrets
 	if warning := detectSecrets(content); warning != "" {


### PR DESCRIPTION
Automatically infers area/sub_area from memory content. No manual tagging needed. Covers work (Power Platform, Fabric, TD SYNNEX), homelab (Proxmox, Traefik, Vault, DNS), project (claude-memory, distify, labctl), home (LEGO, streaming, gaming), family. Closes #15