### PR TITLE
feat: auto-inject memories on session start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,12 @@ claude mcp add -s user claude-memory -- claude-memory
 | `list_memories` | Browse/filter without semantic search |
 | `update_memory` | Modify content/metadata, re-embeds if changed |
 
+## Session Start
+
+At the beginning of every session, read the `memory://context` resource to get
+recent and important memories pre-loaded. This ensures you have relevant context
+without needing explicit recall calls.
+
 ## Conventions
 
 - One struct per file, file named after the struct

--- a/db/memory.go
+++ b/db/memory.go
@@ -599,6 +599,46 @@ func hasDiagnosticKeywords(query string) bool {
 	return false
 }
 
+// GetContextMemories returns memories for session auto-injection:
+// recent (7 days) memories, optionally filtered by project.
+func (c *Client) GetContextMemories(project string, limit int) ([]*Memory, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	var conditions []string
+	var args []any
+
+	conditions = append(conditions, "m.archived_at IS NULL")
+	conditions = append(conditions, `m.created_at > datetime("now", "-7 days")`)
+	conditions = append(conditions, "m.visibility != 'private'")
+
+	if project != "" {
+		conditions = append(conditions, "m.project = ?")
+		args = append(args, project)
+	}
+
+	args = append(args, limit)
+
+	query := fmt.Sprintf(`
+		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
+		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
+		       m.created_at, m.updated_at, m.archived_at, m.token_count
+		FROM memories m
+		WHERE %s
+		ORDER BY m.created_at DESC
+		LIMIT ?
+	`, strings.Join(conditions, " AND "))
+
+	rows, err := c.DB.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("getting context memories: %w", err)
+	}
+	defer rows.Close()
+
+	return scanMemories(rows)
+}
+
 // FindSimilar returns the single closest non-archived memory by cosine distance.
 // Returns nil if no memories exist or the closest distance exceeds maxDistance.
 func (c *Client) FindSimilar(embedding []float32, maxDistance float64) (*VectorResult, error) {

--- a/resources/context.go
+++ b/resources/context.go
@@ -1,0 +1,54 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/j33pguy/claude-memory/db"
+)
+
+// Context provides recent and important memories for session auto-injection.
+type Context struct {
+	DB *db.Client
+}
+
+// Resource returns the MCP resource definition for context.
+func (c *Context) Resource() mcp.Resource {
+	return mcp.NewResource(
+		"memory://context",
+		"Session Context",
+		mcp.WithResourceDescription("Recent memories auto-injected at session start"),
+		mcp.WithMIMEType("application/json"),
+	)
+}
+
+// Handle returns recent memories for session context priming.
+func (c *Context) Handle(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	project := os.Getenv("PROJECT_NAME")
+
+	memories, err := c.DB.GetContextMemories(project, 10)
+	if err != nil {
+		return nil, fmt.Errorf("getting context memories: %w", err)
+	}
+
+	if memories == nil {
+		memories = []*db.Memory{}
+	}
+
+	data, err := json.MarshalIndent(memories, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling context memories: %w", err)
+	}
+
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      "memory://context",
+			MIMEType: "application/json",
+			Text:     string(data),
+		},
+	}, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -131,6 +131,9 @@ func (s *Server) registerResources() {
 
 	prefs := &resources.Preferences{DB: s.dbClient}
 	s.mcp.AddResource(prefs.Resource(), prefs.Handle)
+
+	ctx := &resources.Context{DB: s.dbClient}
+	s.mcp.AddResource(ctx.Resource(), ctx.Handle)
 }
 
 // ServeGRPC starts the gRPC server. Blocks until the server stops.


### PR DESCRIPTION
## Summary
- Adds `memory://context` MCP resource that returns recent (7-day) memories at session start
- Claude Code reads this resource to stay context-primed without explicit recall calls
- New `GetContextMemories` DB method with optional project filtering

## Changes
- `resources/context.go` — new static resource handler (`memory://context`)
- `db/memory.go` — `GetContextMemories(project, limit)` query method
- `server/server.go` — wires context resource into `registerResources()`
- `CLAUDE.md` — documents session start behavior

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify `memory://context` returns JSON array of recent memories via MCP inspector
- [ ] Verify empty DB returns `[]` (not error)
- [ ] Verify `PROJECT_NAME` env var filters by project

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)