### PR TITLE
feat: contradiction detection on memory write

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ Claude Code (stdio) → claude-memory (Go binary)
 - `main.go` — Entry point, stdio MCP server
 - `server/` — MCP server setup, tool/resource registration
 - `db/` — Turso client, schema migrations, Memory CRUD, tags
-- `tools/` — MCP tool handlers (remember, recall, forget, list, update)
+- `tools/` — MCP tool handlers (remember, recall, forget, list, update, check_contradictions)
+- `contradiction/` — Contradiction detection heuristics
 - `resources/` — MCP resource handlers (recent, decisions, preferences)
 - `embeddings/` — ONNX embedding provider + BERT WordPiece tokenizer
 - `chunking/` — Markdown-aware text splitter
@@ -70,6 +71,7 @@ claude mcp add -s user claude-memory -- claude-memory
 | `update_memory` | Modify content/metadata, re-embeds if changed |
 | `index_turn` | Index a single conversation turn as a memory |
 | `index_session` | Bulk-index a completed conversation session |
+| `check_contradictions` | Check if content contradicts existing memories |
 
 ## Passive Indexing
 
@@ -86,11 +88,16 @@ At the beginning of every session, read the `memory://context` resource to get
 recent and important memories pre-loaded. This ensures you have relevant context
 without needing explicit recall calls.
 
-## Session Start
+## Contradiction Detection
 
-At the beginning of every session, read the `memory://context` resource to get
-recent and important memories pre-loaded. This ensures you have relevant context
-without needing explicit recall calls.
+When `remember` stores a new memory, it automatically checks for potential contradictions
+against existing memories in the same area/sub_area. If contradictions are found, they are
+returned as warnings alongside the saved memory ID — writes are never blocked.
+
+When `remember` returns contradiction warnings, review the candidates.
+If the new memory supersedes the old one, call `forget` to archive the old memory,
+or call `update_memory` to modify it. The standalone `check_contradictions` tool can also
+be used to check content before storing.
 
 ## Conventions
 

--- a/contradiction/detect.go
+++ b/contradiction/detect.go
@@ -1,0 +1,252 @@
+// Package contradiction detects potential contradictions between new and existing memories.
+package contradiction
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/claude-memory/embeddings"
+)
+
+// Candidate is a potentially contradicting memory pair.
+type Candidate struct {
+	ExistingID      string  `json:"existing_id"`
+	ExistingSummary string  `json:"existing_summary"`
+	NewContent      string  `json:"new_content"`
+	Score           float64 `json:"score"` // contradiction likelihood 0.0–1.0
+	Similarity      float64 `json:"similarity"`
+	Reason          string  `json:"reason"`
+}
+
+// Detector checks new memories against existing ones for potential contradictions.
+type Detector struct {
+	// Threshold is the minimum similarity above which we flag as potential contradiction.
+	// High similarity + same area = possible conflict. Default 0.85.
+	Threshold float64
+}
+
+// Check runs contradiction detection. It embeds newContent, searches for highly similar
+// memories in the same area/sub_area, then applies heuristic filters to identify likely
+// contradictions vs just related memories.
+func (d *Detector) Check(ctx context.Context, dbClient *db.Client, embedder embeddings.Provider, newContent, area, subArea string) ([]Candidate, error) {
+	threshold := d.Threshold
+	if threshold <= 0 {
+		threshold = 0.85
+	}
+
+	// Embed the new content
+	embedding, err := embedder.Embed(ctx, newContent)
+	if err != nil {
+		return nil, fmt.Errorf("embedding new content: %w", err)
+	}
+
+	// Search for similar memories in the same area/sub_area
+	filter := &db.MemoryFilter{
+		Visibility: "all",
+	}
+	if area != "" {
+		filter.Area = area
+	}
+	if subArea != "" {
+		filter.SubArea = subArea
+	}
+
+	// Convert similarity threshold to max cosine distance
+	maxDistance := 1.0 - threshold
+
+	results, err := dbClient.SearchMemories(embedding, filter, 10)
+	if err != nil {
+		return nil, fmt.Errorf("searching similar memories: %w", err)
+	}
+
+	var candidates []Candidate
+	for _, r := range results {
+		// Skip results below our similarity threshold
+		if r.Distance > maxDistance {
+			continue
+		}
+
+		similarity := 1.0 - r.Distance
+		score, reason := scoreContradiction(newContent, r.Memory.Content)
+
+		if score <= 0.5 {
+			continue
+		}
+
+		summary := r.Memory.Summary
+		if summary == "" {
+			summary = truncate(r.Memory.Content, 120)
+		}
+
+		candidates = append(candidates, Candidate{
+			ExistingID:      r.Memory.ID,
+			ExistingSummary: summary,
+			NewContent:      truncate(newContent, 120),
+			Score:           score,
+			Similarity:      similarity,
+			Reason:          reason,
+		})
+
+		slog.Info("contradiction candidate",
+			"existing_id", r.Memory.ID,
+			"similarity", fmt.Sprintf("%.2f", similarity),
+			"score", fmt.Sprintf("%.2f", score),
+			"reason", reason,
+		)
+	}
+
+	return candidates, nil
+}
+
+// scoreContradiction applies heuristics to determine if two similar texts contradict.
+// Returns a score (0.0–1.0) and a human-readable reason.
+func scoreContradiction(newText, existingText string) (float64, string) {
+	newLower := strings.ToLower(newText)
+	existingLower := strings.ToLower(existingText)
+
+	var score float64
+	var reasons []string
+
+	// Heuristic 1: Numeric value changes near the same keyword
+	if s := numericChangeScore(newLower, existingLower); s > 0 {
+		score += s
+		reasons = append(reasons, "numeric value differs")
+	}
+
+	// Heuristic 2: Boolean flips
+	if s := booleanFlipScore(newLower, existingLower); s > 0 {
+		score += s
+		reasons = append(reasons, "boolean/state flip")
+	}
+
+	// Heuristic 3: Replacement language in the new text
+	if s := replacementScore(newLower); s > 0 {
+		score += s
+		reasons = append(reasons, "replacement language detected")
+	}
+
+	// Cap at 1.0
+	if score > 1.0 {
+		score = 1.0
+	}
+
+	reason := strings.Join(reasons, "; ")
+	if reason == "" {
+		reason = "high similarity only"
+	}
+
+	return score, reason
+}
+
+// numericChangeScore detects when the same keyword appears near different numbers.
+// e.g., "VLAN 5" vs "VLAN 150" or "port 8300" vs "port 8301"
+func numericChangeScore(newText, existingText string) float64 {
+	// Extract keyword-number pairs from both texts
+	newPairs := extractKeywordNumbers(newText)
+	existingPairs := extractKeywordNumbers(existingText)
+
+	for keyword, newNums := range newPairs {
+		if existingNums, ok := existingPairs[keyword]; ok {
+			// Same keyword found in both — check if numbers differ
+			for _, nn := range newNums {
+				for _, en := range existingNums {
+					if nn != en {
+						return 0.7
+					}
+				}
+			}
+		}
+	}
+
+	return 0
+}
+
+// keywordNumberRe matches patterns like "vlan 5", "port 8300", "version 2.1"
+var keywordNumberRe = regexp.MustCompile(`(\b[a-z][a-z_-]+)\s+(\d+(?:\.\d+)?)`)
+
+// extractKeywordNumbers returns a map of keyword → numbers found near it.
+func extractKeywordNumbers(text string) map[string][]string {
+	pairs := make(map[string][]string)
+	matches := keywordNumberRe.FindAllStringSubmatch(text, -1)
+	for _, m := range matches {
+		keyword := m[1]
+		number := m[2]
+		pairs[keyword] = append(pairs[keyword], number)
+	}
+	return pairs
+}
+
+// booleanFlipScore detects state reversals like "enabled" vs "disabled".
+var booleanPairs = [][2]string{
+	{"enabled", "disabled"},
+	{"is not", "is"},
+	{"true", "false"},
+	{"yes", "no"},
+	{"active", "inactive"},
+	{"on", "off"},
+	{"allow", "deny"},
+	{"allow", "block"},
+	{"open", "closed"},
+	{"up", "down"},
+}
+
+func booleanFlipScore(newText, existingText string) float64 {
+	for _, pair := range booleanPairs {
+		a, b := pair[0], pair[1]
+		// Check if new has one and existing has the other (in either direction)
+		newHasA := containsWord(newText, a)
+		newHasB := containsWord(newText, b)
+		existHasA := containsWord(existingText, a)
+		existHasB := containsWord(existingText, b)
+
+		if (newHasA && existHasB && !existHasA) || (newHasB && existHasA && !existHasB) {
+			return 0.6
+		}
+	}
+	return 0
+}
+
+// containsWord checks for a whole-word match (bounded by non-alpha chars).
+var wordBoundaryCache = make(map[string]*regexp.Regexp)
+
+func containsWord(text, word string) bool {
+	re, ok := wordBoundaryCache[word]
+	if !ok {
+		re = regexp.MustCompile(`\b` + regexp.QuoteMeta(word) + `\b`)
+		wordBoundaryCache[word] = re
+	}
+	return re.MatchString(text)
+}
+
+// replacementScore detects language indicating an update/change.
+var replacementPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\b(changed|moved|migrated)\s+(to|from)\b`),
+	regexp.MustCompile(`\bnow\s+(uses?|is|runs?|on|at)\b`),
+	regexp.MustCompile(`\bupdated?\s+(to|from)\b`),
+	regexp.MustCompile(`\bwas\s+.{1,30},?\s*now\b`),
+	regexp.MustCompile(`\bno longer\b`),
+	regexp.MustCompile(`\binstead of\b`),
+	regexp.MustCompile(`\breplaced?\s+(with|by)\b`),
+	regexp.MustCompile(`\bswitched\s+(to|from)\b`),
+}
+
+func replacementScore(text string) float64 {
+	for _, re := range replacementPatterns {
+		if re.MatchString(text) {
+			return 0.4
+		}
+	}
+	return 0
+}
+
+// truncate shortens a string to maxLen, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/contradiction/detect_test.go
+++ b/contradiction/detect_test.go
@@ -1,0 +1,211 @@
+package contradiction
+
+import (
+	"testing"
+)
+
+func TestScoreContradiction_NumericChange(t *testing.T) {
+	tests := []struct {
+		name        string
+		newText     string
+		existing    string
+		wantMin     float64
+		wantReason  string
+	}{
+		{
+			name:       "VLAN number change",
+			newText:    "proxmox is on vlan 150",
+			existing:   "proxmox is on vlan 5",
+			wantMin:    0.7,
+			wantReason: "numeric value differs",
+		},
+		{
+			name:       "port number change",
+			newText:    "port 8301 is grpc",
+			existing:   "port 8300 is grpc",
+			wantMin:    0.7,
+			wantReason: "numeric value differs",
+		},
+		{
+			name:       "version change",
+			newText:    "running version 3.2",
+			existing:   "running version 2.1",
+			wantMin:    0.7,
+			wantReason: "numeric value differs",
+		},
+		{
+			name:     "same numbers no contradiction",
+			newText:  "proxmox is on vlan 5",
+			existing: "proxmox is on vlan 5",
+			wantMin:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, reason := scoreContradiction(tt.newText, tt.existing)
+			if score < tt.wantMin {
+				t.Errorf("scoreContradiction() score = %v, want >= %v", score, tt.wantMin)
+			}
+			if tt.wantReason != "" && !contains(reason, tt.wantReason) {
+				t.Errorf("scoreContradiction() reason = %q, want to contain %q", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestScoreContradiction_BooleanFlip(t *testing.T) {
+	tests := []struct {
+		name     string
+		newText  string
+		existing string
+		wantMin  float64
+	}{
+		{
+			name:     "enabled vs disabled",
+			newText:  "the firewall is disabled",
+			existing: "the firewall is enabled",
+			wantMin:  0.6,
+		},
+		{
+			name:     "true vs false",
+			newText:  "auto-deploy is false",
+			existing: "auto-deploy is true",
+			wantMin:  0.6,
+		},
+		{
+			name:     "active vs inactive",
+			newText:  "the service is inactive",
+			existing: "the service is active",
+			wantMin:  0.6,
+		},
+		{
+			name:     "same state no contradiction",
+			newText:  "the firewall is enabled",
+			existing: "the firewall is enabled",
+			wantMin:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, _ := scoreContradiction(tt.newText, tt.existing)
+			if score < tt.wantMin {
+				t.Errorf("scoreContradiction() score = %v, want >= %v", score, tt.wantMin)
+			}
+		})
+	}
+}
+
+func TestScoreContradiction_ReplacementLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		newText  string
+		existing string
+		wantMin  float64
+	}{
+		{
+			name:     "changed to",
+			newText:  "changed to port 9090",
+			existing: "running on port 8080",
+			wantMin:  0.4,
+		},
+		{
+			name:     "now uses",
+			newText:  "now uses postgres instead",
+			existing: "uses mysql for storage",
+			wantMin:  0.4,
+		},
+		{
+			name:     "no longer",
+			newText:  "no longer using redis",
+			existing: "uses redis for caching",
+			wantMin:  0.4,
+		},
+		{
+			name:     "was X now Y",
+			newText:  "was on vlan 5, now on vlan 150",
+			existing: "proxmox is on vlan 5",
+			wantMin:  0.4,
+		},
+		{
+			name:     "no replacement language",
+			newText:  "proxmox is running well",
+			existing: "proxmox has good uptime",
+			wantMin:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, _ := scoreContradiction(tt.newText, tt.existing)
+			if score < tt.wantMin {
+				t.Errorf("scoreContradiction() score = %v, want >= %v", score, tt.wantMin)
+			}
+		})
+	}
+}
+
+func TestScoreContradiction_CombinedHeuristics(t *testing.T) {
+	// Multiple heuristics should stack up to 1.0
+	score, reason := scoreContradiction(
+		"changed to port 9090, service is now disabled",
+		"running on port 8080, service is enabled",
+	)
+	if score < 0.7 {
+		t.Errorf("combined heuristics score = %v, want >= 0.7", score)
+	}
+	if score > 1.0 {
+		t.Errorf("combined heuristics score = %v, want <= 1.0", score)
+	}
+	if reason == "" {
+		t.Error("combined heuristics should have a reason")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 120); got != "short" {
+		t.Errorf("truncate(short) = %q, want %q", got, "short")
+	}
+
+	long := "this is a very long string that should be truncated because it exceeds the maximum allowed length for display purposes in the contradiction candidate summary"
+	got := truncate(long, 50)
+	if len(got) > 50 {
+		t.Errorf("truncate() len = %d, want <= 50", len(got))
+	}
+	if got[len(got)-3:] != "..." {
+		t.Errorf("truncate() should end with ..., got %q", got)
+	}
+}
+
+func TestExtractKeywordNumbers(t *testing.T) {
+	pairs := extractKeywordNumbers("proxmox is on vlan 150 and port 8300")
+	if nums, ok := pairs["vlan"]; !ok || len(nums) == 0 || nums[0] != "150" {
+		t.Errorf("expected vlan=150, got %v", pairs["vlan"])
+	}
+	if nums, ok := pairs["port"]; !ok || len(nums) == 0 || nums[0] != "8300" {
+		t.Errorf("expected port=8300, got %v", pairs["port"])
+	}
+}
+
+func TestContainsWord(t *testing.T) {
+	if !containsWord("the service is enabled", "enabled") {
+		t.Error("expected to find 'enabled'")
+	}
+	if containsWord("the service is disabled", "enabled") {
+		t.Error("should not match 'enabled' in 'disabled'")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/server/server.go
+++ b/server/server.go
@@ -126,6 +126,9 @@ func (s *Server) registerTools() {
 
 	indexSession := &tools.IndexSession{DB: s.dbClient, Embedder: s.embedder}
 	s.mcp.AddTool(indexSession.Tool(), indexSession.Handle)
+
+	checkContra := &tools.CheckContradictions{DB: s.dbClient, Embedder: s.embedder}
+	s.mcp.AddTool(checkContra.Tool(), checkContra.Handle)
 }
 
 func (s *Server) registerResources() {

--- a/tools/check_contradictions.go
+++ b/tools/check_contradictions.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/j33pguy/claude-memory/contradiction"
+	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/claude-memory/embeddings"
+)
+
+// CheckContradictions exposes contradiction detection as a standalone MCP tool.
+type CheckContradictions struct {
+	DB       *db.Client
+	Embedder embeddings.Provider
+}
+
+// Tool returns the MCP tool definition for check_contradictions.
+func (c *CheckContradictions) Tool() mcp.Tool {
+	return mcp.NewTool("check_contradictions",
+		mcp.WithDescription("Check if content contradicts any existing memories. Returns potential contradictions with similarity scores and reasons."),
+		mcp.WithString("content", mcp.Required(), mcp.Description("The text to check for contradictions against existing memories")),
+		mcp.WithString("area", mcp.Description("Filter to this top-level area (work, home, family, homelab, project, meta)")),
+		mcp.WithString("sub_area", mcp.Description("Filter to this sub-area")),
+		mcp.WithNumber("threshold", mcp.Description("Similarity threshold (0.0-1.0, default 0.85). Higher = stricter matching.")),
+	)
+}
+
+// Handle processes a check_contradictions tool call.
+func (c *CheckContradictions) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	content, err := request.RequireString("content")
+	if err != nil {
+		return mcp.NewToolResultError("content is required"), nil
+	}
+
+	area := request.GetString("area", "")
+	subArea := request.GetString("sub_area", "")
+	threshold := request.GetFloat("threshold", 0.85)
+
+	if threshold < 0 || threshold > 1 {
+		threshold = 0.85
+	}
+
+	detector := &contradiction.Detector{Threshold: threshold}
+	candidates, err := detector.Check(ctx, c.DB, c.Embedder, content, area, subArea)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("checking contradictions: %v", err)), nil
+	}
+
+	if len(candidates) == 0 {
+		return mcp.NewToolResultText("No contradictions detected."), nil
+	}
+
+	data, err := json.Marshal(map[string]any{
+		"contradictions": candidates,
+		"count":          len(candidates),
+	})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("marshaling results: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(data)), nil
+}

--- a/tools/remember.go
+++ b/tools/remember.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/j33pguy/claude-memory/classify"
+	"github.com/j33pguy/claude-memory/contradiction"
 	"github.com/j33pguy/claude-memory/db"
 	"github.com/j33pguy/claude-memory/embeddings"
 )
@@ -159,6 +160,21 @@ func (r *Remember) Handle(ctx context.Context, request mcp.CallToolRequest) (*mc
 	if memory.ParentID != "" {
 		msg += fmt.Sprintf(" [linked to similar memory %s, %.1f%% similar]", memory.ParentID, (1.0-match.Distance)*100)
 	}
+
+	// Contradiction detection (best-effort, never blocks writes)
+	detector := &contradiction.Detector{Threshold: 0.85}
+	candidates, cErr := detector.Check(ctx, r.DB, r.Embedder, content, area, subArea)
+	if cErr != nil {
+		slog.Warn("contradiction detection failed", "error", cErr)
+	} else if len(candidates) > 0 {
+		msg += fmt.Sprintf("\n\n⚠ %d potential contradiction(s) detected:", len(candidates))
+		for _, c := range candidates {
+			msg += fmt.Sprintf("\n  - Memory %s (%.0f%% similar, score=%.2f): %s [%s]",
+				c.ExistingID, c.Similarity*100, c.Score, c.ExistingSummary, c.Reason)
+		}
+		msg += "\n\nReview these and consider updating/superseding the old memory if the new one replaces it."
+	}
+
 	return mcp.NewToolResultText(msg), nil
 }
 


### PR DESCRIPTION
## Summary
- Adds `contradiction` package with heuristic-based detection (numeric changes, boolean flips, replacement language)
- `remember` tool now automatically checks for contradictions after saving — warnings are returned alongside the memory ID, writes are never blocked
- New standalone `check_contradictions` MCP tool for pre-write checking
- 8 test cases covering all heuristic categories

## How it works
1. After saving a memory, embed the new content and search for highly similar memories (≥85% similarity) in the same area/sub_area
2. Apply contradiction heuristics: numeric value changes near same keywords, boolean state flips, replacement language patterns
3. Score each candidate 0.0–1.0; return those above 0.5 as warnings

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + 8 new tests)
- [ ] Manual test: store "Proxmox is on VLAN 5" then "Proxmox is on VLAN 150" → contradiction warning
- [ ] Manual test: `check_contradictions` tool returns candidates for conflicting content
- [ ] Manual test: non-contradicting similar memories do not trigger false positives

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)