### PR TITLE
feat: temporal queries — date-range filters for recall and list

### DIFF
--- a/api/memories.go
+++ b/api/memories.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/claude-memory/tools"
 )
 
 func (s *Server) handleListMemories(w http.ResponseWriter, r *http.Request) {
@@ -23,6 +24,17 @@ func (s *Server) handleListMemories(w http.ResponseWriter, r *http.Request) {
 		tags = strings.Split(t, ",")
 	}
 
+	afterTime, err := tools.ParseTimeParam(q.Get("after"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid 'after': %v", err)})
+		return
+	}
+	beforeTime, err := tools.ParseTimeParam(q.Get("before"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid 'before': %v", err)})
+		return
+	}
+
 	filter := &db.MemoryFilter{
 		Project:    q.Get("project"),
 		Type:       q.Get("type"),
@@ -33,6 +45,8 @@ func (s *Server) handleListMemories(w http.ResponseWriter, r *http.Request) {
 		Speaker:    q.Get("speaker"),
 		Area:       q.Get("area"),
 		SubArea:    q.Get("sub_area"),
+		AfterTime:  afterTime,
+		BeforeTime: beforeTime,
 	}
 
 	memories, err := s.db.ListMemories(filter)

--- a/api/recall.go
+++ b/api/recall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/j33pguy/claude-memory/db"
 	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/claude-memory/tools"
 )
 
 type recallRequest struct {
@@ -21,6 +22,8 @@ type recallRequest struct {
 	Speaker      string   `json:"speaker"`
 	Area         string   `json:"area"`
 	SubArea      string   `json:"sub_area"`
+	After        string   `json:"after"`           // only memories after this time (ISO-8601 or relative: 7d, 2w, 1m)
+	Before       string   `json:"before"`          // only memories before this time
 }
 
 func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
@@ -39,6 +42,17 @@ func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
 		req.TopK = 5
 	}
 
+	afterTime, err := tools.ParseTimeParam(req.After)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid 'after': %v", err)})
+		return
+	}
+	beforeTime, err := tools.ParseTimeParam(req.Before)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid 'before': %v", err)})
+		return
+	}
+
 	filter := &db.MemoryFilter{
 		Project:    req.Project,
 		Projects:   req.Projects,
@@ -48,6 +62,8 @@ func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
 		Speaker:    req.Speaker,
 		Area:       req.Area,
 		SubArea:    req.SubArea,
+		AfterTime:  afterTime,
+		BeforeTime: beforeTime,
 	}
 
 	resp, err := search.Adaptive(r.Context(), s.db, s.embedder.Embed, req.Query, filter, req.TopK, req.MinRelevance, req.RecencyDecay)

--- a/db/memory.go
+++ b/db/memory.go
@@ -59,6 +59,10 @@ type MemoryFilter struct {
 	Area string
 	// SubArea filters by sub-domain (power-platform, proxmox, claude-memory, etc.).
 	SubArea string
+	// AfterTime filters to memories created after this time.
+	AfterTime *time.Time
+	// BeforeTime filters to memories created before this time.
+	BeforeTime *time.Time
 }
 
 // HybridResult wraps a Memory with scores from both retrieval methods.
@@ -203,6 +207,7 @@ func (c *Client) ListMemories(filter *MemoryFilter) ([]*Memory, error) {
 
 	appendProjectCondition(filter, &conditions, &args)
 	appendTaxonomyConditions(filter, &conditions, &args)
+	appendTimeConditions(filter, &conditions, &args)
 	if filter.Type != "" {
 		conditions = append(conditions, "m.type = ?")
 		args = append(args, filter.Type)
@@ -259,6 +264,7 @@ func (c *Client) SearchMemories(embedding []float32, filter *MemoryFilter, topK 
 	if filter != nil {
 		appendProjectCondition(filter, &conditions, &args)
 		appendTaxonomyConditions(filter, &conditions, &args)
+		appendTimeConditions(filter, &conditions, &args)
 		if filter.Type != "" {
 			conditions = append(conditions, "m.type = ?")
 			args = append(args, filter.Type)
@@ -394,6 +400,18 @@ func appendTaxonomyConditions(filter *MemoryFilter, conditions *[]string, args *
 	}
 }
 
+// appendTimeConditions adds after/before time filtering to conditions/args.
+func appendTimeConditions(filter *MemoryFilter, conditions *[]string, args *[]any) {
+	if filter.AfterTime != nil {
+		*conditions = append(*conditions, "m.created_at > ?")
+		*args = append(*args, filter.AfterTime.UTC().Format(time.RFC3339))
+	}
+	if filter.BeforeTime != nil {
+		*conditions = append(*conditions, "m.created_at < ?")
+		*args = append(*args, filter.BeforeTime.UTC().Format(time.RFC3339))
+	}
+}
+
 // appendVisibilityCondition adds visibility filtering to conditions/args.
 func appendVisibilityCondition(filter *MemoryFilter, conditions *[]string, args *[]any) {
 	if filter.Visibility == "all" {
@@ -420,6 +438,7 @@ func (c *Client) SearchMemoriesBM25(query string, filter *MemoryFilter, topK int
 	if filter != nil {
 		appendProjectCondition(filter, &conditions, &args)
 		appendTaxonomyConditions(filter, &conditions, &args)
+		appendTimeConditions(filter, &conditions, &args)
 		if filter.Type != "" {
 			conditions = append(conditions, "m.type = ?")
 			args = append(args, filter.Type)

--- a/db/memory_test.go
+++ b/db/memory_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"testing"
+	"time"
 )
 
 func TestAppendTaxonomyConditions(t *testing.T) {
@@ -105,5 +106,83 @@ func TestMemoryStructTaxonomyFields(t *testing.T) {
 	}
 	if m.SubArea != "power-platform" {
 		t.Errorf("SubArea = %q, want %q", m.SubArea, "power-platform")
+	}
+}
+
+func TestAppendTimeConditions(t *testing.T) {
+	now := time.Now().UTC()
+	past := now.Add(-7 * 24 * time.Hour)
+
+	tests := []struct {
+		name           string
+		filter         *MemoryFilter
+		wantConditions int
+		wantArgs       int
+	}{
+		{
+			name:           "no time filters",
+			filter:         &MemoryFilter{},
+			wantConditions: 0,
+			wantArgs:       0,
+		},
+		{
+			name:           "after only",
+			filter:         &MemoryFilter{AfterTime: &past},
+			wantConditions: 1,
+			wantArgs:       1,
+		},
+		{
+			name:           "before only",
+			filter:         &MemoryFilter{BeforeTime: &now},
+			wantConditions: 1,
+			wantArgs:       1,
+		},
+		{
+			name:           "both after and before",
+			filter:         &MemoryFilter{AfterTime: &past, BeforeTime: &now},
+			wantConditions: 2,
+			wantArgs:       2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var conditions []string
+			var args []any
+
+			appendTimeConditions(tt.filter, &conditions, &args)
+
+			if len(conditions) != tt.wantConditions {
+				t.Errorf("got %d conditions, want %d: %v", len(conditions), tt.wantConditions, conditions)
+			}
+			if len(args) != tt.wantArgs {
+				t.Errorf("got %d args, want %d: %v", len(args), tt.wantArgs, args)
+			}
+		})
+	}
+}
+
+func TestAppendTimeConditions_Values(t *testing.T) {
+	after := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	var conditions []string
+	var args []any
+
+	filter := &MemoryFilter{AfterTime: &after, BeforeTime: &before}
+	appendTimeConditions(filter, &conditions, &args)
+
+	expectedConds := []string{"m.created_at > ?", "m.created_at < ?"}
+	for i, want := range expectedConds {
+		if conditions[i] != want {
+			t.Errorf("condition[%d] = %q, want %q", i, conditions[i], want)
+		}
+	}
+
+	expectedArgs := []string{"2026-01-01T00:00:00Z", "2026-03-01T00:00:00Z"}
+	for i, want := range expectedArgs {
+		if args[i] != want {
+			t.Errorf("args[%d] = %v, want %v", i, args[i], want)
+		}
 	}
 }

--- a/db/schema.go
+++ b/db/schema.go
@@ -30,6 +30,7 @@ func (s *Schema) run() error {
 		{3, migrationV3},
 		{4, migrationV4},
 		{5, migrationV5},
+		{6, migrationV6},
 	}
 
 	for _, m := range migrations {
@@ -222,6 +223,12 @@ ALTER TABLE memories ADD COLUMN sub_area TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_memories_speaker ON memories(speaker) WHERE speaker != '';
 CREATE INDEX IF NOT EXISTS idx_memories_area ON memories(area) WHERE area != '';
 CREATE INDEX IF NOT EXISTS idx_memories_area_sub ON memories(area, sub_area) WHERE area != '';
+`
+
+// migrationV6 adds a dedicated index on created_at for temporal queries
+// (after/before time filtering).
+const migrationV6 = `
+CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);
 `
 
 // migrationV2 adds visibility field for access control.

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/j33pguy/claude-memory/embeddings"
 	pb "github.com/j33pguy/claude-memory/proto/memory/v1"
 	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/claude-memory/tools"
 )
 
 // Server implements the MemoryService gRPC service.
@@ -119,6 +120,15 @@ func (s *Server) Recall(ctx context.Context, req *pb.RecallRequest) (*pb.RecallR
 		topK = 5
 	}
 
+	afterTime, err := tools.ParseTimeParam(req.AfterTime)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid after_time: %v", err)
+	}
+	beforeTime, err := tools.ParseTimeParam(req.BeforeTime)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid before_time: %v", err)
+	}
+
 	filter := &db.MemoryFilter{
 		Project:    req.Project,
 		Projects:   req.Projects,
@@ -128,6 +138,8 @@ func (s *Server) Recall(ctx context.Context, req *pb.RecallRequest) (*pb.RecallR
 		Speaker:    req.Speaker,
 		Area:       req.Area,
 		SubArea:    req.SubArea,
+		AfterTime:  afterTime,
+		BeforeTime: beforeTime,
 	}
 
 	resp, err := search.Adaptive(ctx, s.db, s.embedder.Embed, req.Query, filter, topK, req.MinRelevance, req.RecencyDecay)
@@ -172,6 +184,15 @@ func (s *Server) List(_ context.Context, req *pb.ListRequest) (*pb.ListResponse,
 		tags = strings.Split(req.Tags, ",")
 	}
 
+	afterTime, err := tools.ParseTimeParam(req.AfterTime)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid after_time: %v", err)
+	}
+	beforeTime, err := tools.ParseTimeParam(req.BeforeTime)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid before_time: %v", err)
+	}
+
 	filter := &db.MemoryFilter{
 		Project:    req.Project,
 		Type:       req.Type,
@@ -182,6 +203,8 @@ func (s *Server) List(_ context.Context, req *pb.ListRequest) (*pb.ListResponse,
 		Speaker:    req.Speaker,
 		Area:       req.Area,
 		SubArea:    req.SubArea,
+		AfterTime:  afterTime,
+		BeforeTime: beforeTime,
 	}
 
 	memories, err := s.db.ListMemories(filter)

--- a/proto/memory/v1/memory.pb.go
+++ b/proto/memory/v1/memory.pb.go
@@ -490,6 +490,8 @@ type RecallRequest struct {
 	Speaker       string                 `protobuf:"bytes,9,opt,name=speaker,proto3" json:"speaker,omitempty"`
 	Area          string                 `protobuf:"bytes,10,opt,name=area,proto3" json:"area,omitempty"`
 	SubArea       string                 `protobuf:"bytes,11,opt,name=sub_area,json=subArea,proto3" json:"sub_area,omitempty"`
+	AfterTime     string                 `protobuf:"bytes,12,opt,name=after_time,json=afterTime,proto3" json:"after_time,omitempty"`
+	BeforeTime    string                 `protobuf:"bytes,13,opt,name=before_time,json=beforeTime,proto3" json:"before_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -597,6 +599,20 @@ func (x *RecallRequest) GetArea() string {
 func (x *RecallRequest) GetSubArea() string {
 	if x != nil {
 		return x.SubArea
+	}
+	return ""
+}
+
+func (x *RecallRequest) GetAfterTime() string {
+	if x != nil {
+		return x.AfterTime
+	}
+	return ""
+}
+
+func (x *RecallRequest) GetBeforeTime() string {
+	if x != nil {
+		return x.BeforeTime
 	}
 	return ""
 }
@@ -777,6 +793,8 @@ type ListRequest struct {
 	Speaker       string                 `protobuf:"bytes,6,opt,name=speaker,proto3" json:"speaker,omitempty"`
 	Area          string                 `protobuf:"bytes,7,opt,name=area,proto3" json:"area,omitempty"`
 	SubArea       string                 `protobuf:"bytes,8,opt,name=sub_area,json=subArea,proto3" json:"sub_area,omitempty"`
+	AfterTime     string                 `protobuf:"bytes,9,opt,name=after_time,json=afterTime,proto3" json:"after_time,omitempty"`
+	BeforeTime    string                 `protobuf:"bytes,10,opt,name=before_time,json=beforeTime,proto3" json:"before_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -863,6 +881,20 @@ func (x *ListRequest) GetArea() string {
 func (x *ListRequest) GetSubArea() string {
 	if x != nil {
 		return x.SubArea
+	}
+	return ""
+}
+
+func (x *ListRequest) GetAfterTime() string {
+	if x != nil {
+		return x.AfterTime
+	}
+	return ""
+}
+
+func (x *ListRequest) GetBeforeTime() string {
+	if x != nil {
+		return x.BeforeTime
 	}
 	return ""
 }

--- a/proto/memory/v1/memory.proto
+++ b/proto/memory/v1/memory.proto
@@ -115,6 +115,8 @@ message RecallRequest {
   string speaker = 9;
   string area = 10;
   string sub_area = 11;
+  string after_time = 12;   // only memories after this time (ISO-8601 or relative: 7d, 2w, 1m)
+  string before_time = 13;  // only memories before this time
 }
 
 message RecallResponse {
@@ -144,6 +146,8 @@ message ListRequest {
   string speaker = 6;
   string area = 7;
   string sub_area = 8;
+  string after_time = 9;   // only memories after this time (ISO-8601 or relative: 7d, 2w, 1m)
+  string before_time = 10;  // only memories before this time
 }
 
 message ListResponse {

--- a/tools/list.go
+++ b/tools/list.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/j33pguy/claude-memory/db"
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // List browses/filters memories without semantic search.
@@ -35,20 +35,33 @@ func (l *List) Tool() mcp.Tool {
 			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
 		),
 		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, claude-memory)")),
+		mcp.WithString("after", mcp.Description("Only memories created after this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
+		mcp.WithString("before", mcp.Description("Only memories created before this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
 	)
 }
 
 // Handle processes a list_memories tool call.
 func (l *List) Handle(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	afterTime, err := ParseTimeParam(request.GetString("after", ""))
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid 'after': %v", err)), nil
+	}
+	beforeTime, err := ParseTimeParam(request.GetString("before", ""))
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid 'before': %v", err)), nil
+	}
+
 	filter := &db.MemoryFilter{
-		Project: request.GetString("project", ""),
-		Type:    request.GetString("type", ""),
-		Tags:    request.GetStringSlice("tags", nil),
-		Limit:   request.GetInt("limit", 20),
-		Offset:  request.GetInt("offset", 0),
-		Speaker: request.GetString("speaker", ""),
-		Area:    request.GetString("area", ""),
-		SubArea: request.GetString("sub_area", ""),
+		Project:    request.GetString("project", ""),
+		Type:       request.GetString("type", ""),
+		Tags:       request.GetStringSlice("tags", nil),
+		Limit:      request.GetInt("limit", 20),
+		Offset:     request.GetInt("offset", 0),
+		Speaker:    request.GetString("speaker", ""),
+		Area:       request.GetString("area", ""),
+		SubArea:    request.GetString("sub_area", ""),
+		AfterTime:  afterTime,
+		BeforeTime: beforeTime,
 	}
 
 	memories, err := l.DB.ListMemories(filter)

--- a/tools/recall.go
+++ b/tools/recall.go
@@ -41,6 +41,8 @@ func (r *Recall) Tool() mcp.Tool {
 			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
 		),
 		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, claude-memory)")),
+		mcp.WithString("after", mcp.Description("Only memories created after this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
+		mcp.WithString("before", mcp.Description("Only memories created before this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
 	)
 }
 
@@ -62,6 +64,18 @@ func (r *Recall) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.
 	area := request.GetString("area", "")
 	subArea := request.GetString("sub_area", "")
 
+	afterStr := request.GetString("after", "")
+	beforeStr := request.GetString("before", "")
+
+	afterTime, err := ParseTimeParam(afterStr)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid 'after': %v", err)), nil
+	}
+	beforeTime, err := ParseTimeParam(beforeStr)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid 'before': %v", err)), nil
+	}
+
 	filter := &db.MemoryFilter{
 		Project:    project,
 		Projects:   projects,
@@ -71,6 +85,8 @@ func (r *Recall) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.
 		Speaker:    speaker,
 		Area:       area,
 		SubArea:    subArea,
+		AfterTime:  afterTime,
+		BeforeTime: beforeTime,
 	}
 
 	resp, err := search.Adaptive(ctx, r.DB, r.Embedder.Embed, query, filter, topK, minRelevance, recencyDecay)

--- a/tools/timeparse.go
+++ b/tools/timeparse.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+var relativePattern = regexp.MustCompile(`^(\d+)([dwmyDWMY])$`)
+
+// parseTimeParam parses a time string that is either a relative duration
+// ("7d", "2w", "1m", "1y") or an absolute date ("2006-01-02" or RFC3339).
+func ParseTimeParam(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	// Try relative: "7d", "2w", "1m", "1y"
+	if matched := relativePattern.FindStringSubmatch(s); matched != nil {
+		n, _ := strconv.Atoi(matched[1])
+		now := time.Now().UTC()
+		var t time.Time
+		switch matched[2] {
+		case "d", "D":
+			t = now.AddDate(0, 0, -n)
+		case "w", "W":
+			t = now.AddDate(0, 0, -n*7)
+		case "m", "M":
+			t = now.AddDate(0, -n, 0)
+		case "y", "Y":
+			t = now.AddDate(-n, 0, 0)
+		}
+		return &t, nil
+	}
+
+	// Try RFC3339: "2006-01-02T15:04:05Z"
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return &t, nil
+	}
+
+	// Try date only: "2006-01-02"
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return &t, nil
+	}
+
+	return nil, fmt.Errorf("invalid time format %q: use relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339)", s)
+}

--- a/tools/timeparse_test.go
+++ b/tools/timeparse_test.go
@@ -1,0 +1,147 @@
+package tools
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTimeParam(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+		wantErr bool
+		check   func(t *testing.T, got *time.Time)
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			wantNil: true,
+		},
+		{
+			name: "7d relative",
+			input: "7d",
+			check: func(t *testing.T, got *time.Time) {
+				expected := now.AddDate(0, 0, -7)
+				diff := got.Sub(expected).Abs()
+				if diff > 2*time.Second {
+					t.Errorf("7d: got %v, want ~%v (diff %v)", got, expected, diff)
+				}
+			},
+		},
+		{
+			name: "2w relative",
+			input: "2w",
+			check: func(t *testing.T, got *time.Time) {
+				expected := now.AddDate(0, 0, -14)
+				diff := got.Sub(expected).Abs()
+				if diff > 2*time.Second {
+					t.Errorf("2w: got %v, want ~%v (diff %v)", got, expected, diff)
+				}
+			},
+		},
+		{
+			name: "1m relative",
+			input: "1m",
+			check: func(t *testing.T, got *time.Time) {
+				expected := now.AddDate(0, -1, 0)
+				diff := got.Sub(expected).Abs()
+				if diff > 2*time.Second {
+					t.Errorf("1m: got %v, want ~%v (diff %v)", got, expected, diff)
+				}
+			},
+		},
+		{
+			name: "1y relative",
+			input: "1y",
+			check: func(t *testing.T, got *time.Time) {
+				expected := now.AddDate(-1, 0, 0)
+				diff := got.Sub(expected).Abs()
+				if diff > 2*time.Second {
+					t.Errorf("1y: got %v, want ~%v (diff %v)", got, expected, diff)
+				}
+			},
+		},
+		{
+			name: "date only",
+			input: "2026-03-01",
+			check: func(t *testing.T, got *time.Time) {
+				expected := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+				if !got.Equal(expected) {
+					t.Errorf("date: got %v, want %v", got, expected)
+				}
+			},
+		},
+		{
+			name: "RFC3339",
+			input: "2026-03-01T00:00:00Z",
+			check: func(t *testing.T, got *time.Time) {
+				expected := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+				if !got.Equal(expected) {
+					t.Errorf("RFC3339: got %v, want %v", got, expected)
+				}
+			},
+		},
+		{
+			name:    "invalid",
+			input:   "not-a-date",
+			wantErr: true,
+		},
+		{
+			name:    "invalid unit",
+			input:   "7x",
+			wantErr: true,
+		},
+		{
+			name: "30d relative",
+			input: "30d",
+			check: func(t *testing.T, got *time.Time) {
+				expected := now.AddDate(0, 0, -30)
+				diff := got.Sub(expected).Abs()
+				if diff > 2*time.Second {
+					t.Errorf("30d: got %v, want ~%v (diff %v)", got, expected, diff)
+				}
+			},
+		},
+		{
+			name: "uppercase 7D",
+			input: "7D",
+			check: func(t *testing.T, got *time.Time) {
+				expected := now.AddDate(0, 0, -7)
+				diff := got.Sub(expected).Abs()
+				if diff > 2*time.Second {
+					t.Errorf("7D: got %v, want ~%v (diff %v)", got, expected, diff)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTimeParam(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil for %q, got %v", tt.input, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil for %q", tt.input)
+			}
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `after` / `before` time filters to `recall`, `list_memories`, and all API surfaces (MCP tools, gRPC, HTTP REST)
- Supports ISO-8601 (`2026-03-01`, `2026-03-01T00:00:00Z`) and relative formats (`7d`, `2w`, `1m`, `1y`)
- Adds DB migration V6 with `created_at` index for temporal query performance
- New `tools/timeparse.go` with `ParseTimeParam` — shared across MCP, gRPC, and HTTP layers

## Changes
| File | Change |
|------|--------|
| `db/memory.go` | `AfterTime`/`BeforeTime` on `MemoryFilter`, `appendTimeConditions` helper |
| `db/schema.go` | Migration V6: `idx_memories_created_at` |
| `tools/timeparse.go` | Relative + absolute time parser |
| `tools/recall.go` | `after`/`before` params on recall tool |
| `tools/list.go` | `after`/`before` params on list_memories tool |
| `grpc/server.go` | Extract time filters in Recall/List handlers |
| `proto/memory/v1/memory.proto` | `after_time`/`before_time` fields on RecallRequest, ListRequest |
| `proto/memory/v1/memory.pb.go` | Manual update (buf unavailable) |
| `api/recall.go` | `after`/`before` on HTTP recall endpoint |
| `api/memories.go` | `after`/`before` query params on HTTP list endpoint |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 6 test packages)
- [x] `tools/timeparse_test.go`: relative (7d, 2w, 1m, 1y, 30d), date-only, RFC3339, invalid, uppercase
- [x] `db/memory_test.go`: appendTimeConditions count + value tests
- [ ] Manual: verify recall with `after: "7d"` returns only recent memories
- [ ] Manual: verify list with `before: "2026-01-01"` excludes newer memories

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)