### PR TITLE
feat: ingestion pipeline — import Grok/ChatGPT conversations

### DIFF
--- a/ingest/dedup.go
+++ b/ingest/dedup.go
@@ -1,0 +1,45 @@
+package ingest
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Embedder generates vector embeddings for text.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+// DBClient provides deduplication-related database queries.
+type DBClient interface {
+	ExistsWithContentHash(hash string) (string, error)
+}
+
+// Deduplicator checks new memories against existing ones to prevent duplicates.
+type Deduplicator struct {
+	DB       DBClient
+	Embedder Embedder
+}
+
+// dedupThreshold is the cosine similarity above which memories are considered duplicates.
+const dedupThreshold = 0.92
+
+// Filter removes memories from candidates that are too similar to existing ones.
+// Uses content-hash dedup (exact match via SHA-256 prefix).
+func (d *Deduplicator) Filter(ctx context.Context, candidates []ExtractedMemory) (kept []ExtractedMemory, skipped int, err error) {
+	for _, c := range candidates {
+		hash := contentHash(c.Content)
+		existingID, err := d.DB.ExistsWithContentHash(hash)
+		if err != nil {
+			slog.Warn("dedup hash check failed, keeping candidate", "error", err)
+			kept = append(kept, c)
+			continue
+		}
+		if existingID != "" {
+			skipped++
+			continue
+		}
+		kept = append(kept, c)
+	}
+	return kept, skipped, nil
+}

--- a/ingest/extractor.go
+++ b/ingest/extractor.go
@@ -1,0 +1,151 @@
+package ingest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ExtractedMemory is a memory extracted from a conversation, ready for storage.
+type ExtractedMemory struct {
+	Content string
+	Type    string   // "decision" | "lesson" | "preference" | "project_context" | "conversation"
+	Summary string
+	Speaker string
+	Tags    []string
+	Source  string // "grok", "chatgpt", etc.
+}
+
+// ExtractMemories analyzes a ParsedConversation and extracts meaningful memories.
+func ExtractMemories(conv *ParsedConversation) []ExtractedMemory {
+	if conv == nil || len(conv.Turns) == 0 {
+		return nil
+	}
+
+	var memories []ExtractedMemory
+
+	for i, turn := range conv.Turns {
+		content := strings.TrimSpace(turn.Content)
+		if content == "" {
+			continue
+		}
+
+		speaker := mapSpeaker(turn.Role, conv.Source)
+
+		// Check heuristic categories in priority order
+		if matchesDecision(content) {
+			memories = append(memories, ExtractedMemory{
+				Content: content,
+				Type:    "decision",
+				Summary: summarize(content),
+				Speaker: speaker,
+				Tags:    buildTags(conv.Source, "decision"),
+				Source:  conv.Source,
+			})
+			continue
+		}
+
+		if matchesLesson(content) {
+			memories = append(memories, ExtractedMemory{
+				Content: content,
+				Type:    "lesson",
+				Summary: summarize(content),
+				Speaker: speaker,
+				Tags:    buildTags(conv.Source, "lesson"),
+				Source:  conv.Source,
+			})
+			continue
+		}
+
+		if matchesPreference(content) {
+			memories = append(memories, ExtractedMemory{
+				Content: content,
+				Type:    "preference",
+				Summary: summarize(content),
+				Speaker: speaker,
+				Tags:    buildTags(conv.Source, "preference"),
+				Source:  conv.Source,
+			})
+			continue
+		}
+
+		// Project context: first 3 turns of conversation
+		if i < 3 {
+			memories = append(memories, ExtractedMemory{
+				Content: content,
+				Type:    "project_context",
+				Summary: summarize(content),
+				Speaker: speaker,
+				Tags:    buildTags(conv.Source, "project_context"),
+				Source:  conv.Source,
+			})
+			continue
+		}
+
+		// General conversation: only if > 200 chars
+		if len(content) > 200 {
+			memories = append(memories, ExtractedMemory{
+				Content: content,
+				Type:    "conversation",
+				Summary: summarize(content),
+				Speaker: speaker,
+				Tags:    buildTags(conv.Source, "conversation"),
+				Source:  conv.Source,
+			})
+		}
+	}
+
+	return memories
+}
+
+// --- Heuristic matchers ---
+
+var decisionPatterns = regexp.MustCompile(`(?i)\b(decided|will use|going with|switching to|chose|settled on)\b`)
+
+func matchesDecision(content string) bool {
+	return decisionPatterns.MatchString(content)
+}
+
+var lessonPatterns = regexp.MustCompile(`(?i)\b(learned|figured out|turns out|the issue was|fixed by|root cause)\b`)
+
+func matchesLesson(content string) bool {
+	return lessonPatterns.MatchString(content)
+}
+
+var preferencePatterns = regexp.MustCompile(`(?i)\b(I prefer|I like|I want|always use|never use|don't use|do not use)\b`)
+
+func matchesPreference(content string) bool {
+	return preferencePatterns.MatchString(content)
+}
+
+// --- Helpers ---
+
+func summarize(content string) string {
+	// First 100 chars, collapse whitespace
+	s := strings.Join(strings.Fields(content), " ")
+	if len(s) > 100 {
+		return s[:100]
+	}
+	return s
+}
+
+func mapSpeaker(role, source string) string {
+	if role == "user" {
+		return "j33p"
+	}
+	switch source {
+	case "grok":
+		return "grok"
+	case "chatgpt":
+		return "chatgpt"
+	default:
+		return "gilfoyle"
+	}
+}
+
+func buildTags(source, memType string) []string {
+	return []string{
+		"source:" + source,
+		"ingested:true",
+		"type:" + memType,
+	}
+}

--- a/ingest/formats.go
+++ b/ingest/formats.go
@@ -1,0 +1,376 @@
+// Package ingest detects and parses conversation exports from Grok, ChatGPT, and plain text.
+package ingest
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Format represents the detected format of input data.
+type Format string
+
+const (
+	FormatGrok      Format = "grok"
+	FormatChatGPT   Format = "chatgpt"
+	FormatPlainText Format = "plaintext"
+	FormatMarkdown  Format = "markdown"
+	FormatGitRepo   Format = "gitrepo"
+	FormatUnknown   Format = "unknown"
+)
+
+// Turn represents a single conversation turn.
+type Turn struct {
+	Role    string     // "user" | "assistant" | "system"
+	Content string
+	Time    *time.Time
+}
+
+// ParsedConversation is the result of parsing any supported format.
+type ParsedConversation struct {
+	Format Format
+	Turns  []Turn
+	Title  string
+	Source string // "grok", "chatgpt", etc.
+}
+
+// MaxInputSize is the maximum allowed input size (10 MB).
+const MaxInputSize = 10 * 1024 * 1024
+
+// Detect auto-detects the format of the input data.
+func Detect(data []byte) Format {
+	trimmed := strings.TrimSpace(string(data))
+	if len(trimmed) == 0 {
+		return FormatUnknown
+	}
+
+	// Try JSON formats first
+	if trimmed[0] == '[' || trimmed[0] == '{' {
+		if isGrokFormat(data) {
+			return FormatGrok
+		}
+		if isChatGPTFormat(data) {
+			return FormatChatGPT
+		}
+	}
+
+	// Plain text with role markers
+	if plainTextRolePattern.MatchString(trimmed) {
+		return FormatPlainText
+	}
+
+	// Markdown headings
+	if strings.HasPrefix(trimmed, "#") {
+		return FormatMarkdown
+	}
+
+	return FormatUnknown
+}
+
+var plainTextRolePattern = regexp.MustCompile(`(?m)^(Human|User|Assistant):\s`)
+
+// Parse parses input data into a ParsedConversation.
+func Parse(data []byte) (*ParsedConversation, error) {
+	if len(data) > MaxInputSize {
+		return nil, fmt.Errorf("input too large: %d bytes (max %d)", len(data), MaxInputSize)
+	}
+
+	format := Detect(data)
+	switch format {
+	case FormatGrok:
+		return parseGrok(data)
+	case FormatChatGPT:
+		return parseChatGPT(data)
+	case FormatPlainText:
+		return parsePlainText(data)
+	case FormatMarkdown:
+		return parseMarkdown(data)
+	default:
+		return nil, fmt.Errorf("unrecognized format")
+	}
+}
+
+// --- Grok ---
+
+// grokExport is the top-level Grok JSON structure.
+type grokExport struct {
+	ConversationID string    `json:"conversation_id"`
+	Title          string    `json:"title"`
+	CreateTime     string    `json:"create_time"`
+	Turns          []grokTurn `json:"turns"`
+}
+
+type grokTurn struct {
+	Author  grokAuthor  `json:"author"`
+	Content grokContent `json:"content"`
+}
+
+type grokAuthor struct {
+	Role string `json:"role"`
+}
+
+type grokContent struct {
+	ContentType string   `json:"content_type"`
+	Parts       []string `json:"parts"`
+}
+
+func isGrokFormat(data []byte) bool {
+	// Try array of conversations
+	var arr []json.RawMessage
+	if json.Unmarshal(data, &arr) != nil || len(arr) == 0 {
+		return false
+	}
+	// Peek at first element
+	var probe struct {
+		ConversationID string `json:"conversation_id"`
+		Turns          []struct {
+			Author struct {
+				Role string `json:"role"`
+			} `json:"author"`
+		} `json:"turns"`
+	}
+	if json.Unmarshal(arr[0], &probe) != nil {
+		return false
+	}
+	return probe.ConversationID != "" && len(probe.Turns) > 0 && probe.Turns[0].Author.Role != ""
+}
+
+func parseGrok(data []byte) (*ParsedConversation, error) {
+	var convos []grokExport
+	if err := json.Unmarshal(data, &convos); err != nil {
+		return nil, fmt.Errorf("parsing Grok JSON: %w", err)
+	}
+
+	conv := &ParsedConversation{
+		Format: FormatGrok,
+		Source: "grok",
+	}
+
+	for _, c := range convos {
+		if conv.Title == "" {
+			conv.Title = c.Title
+		}
+		for _, t := range c.Turns {
+			role := normalizeRole(t.Author.Role)
+			content := strings.Join(t.Content.Parts, "\n")
+			content = strings.TrimSpace(content)
+			if content == "" {
+				continue
+			}
+			conv.Turns = append(conv.Turns, Turn{Role: role, Content: content})
+		}
+	}
+
+	return conv, nil
+}
+
+// --- ChatGPT ---
+
+type chatGPTExport struct {
+	ID      string                       `json:"id"`
+	Title   string                       `json:"title"`
+	Mapping map[string]chatGPTMappingNode `json:"mapping"`
+}
+
+type chatGPTMappingNode struct {
+	ID       string          `json:"id"`
+	Parent   string          `json:"parent"`
+	Children []string        `json:"children"`
+	Message  *chatGPTMessage `json:"message"`
+}
+
+type chatGPTMessage struct {
+	ID      string            `json:"id"`
+	Author  chatGPTAuthor     `json:"author"`
+	Content chatGPTMsgContent `json:"content"`
+}
+
+type chatGPTAuthor struct {
+	Role string `json:"role"`
+}
+
+type chatGPTMsgContent struct {
+	ContentType string   `json:"content_type"`
+	Parts       []any    `json:"parts"`
+}
+
+func isChatGPTFormat(data []byte) bool {
+	var arr []json.RawMessage
+	if json.Unmarshal(data, &arr) != nil || len(arr) == 0 {
+		return false
+	}
+	var probe struct {
+		Mapping map[string]json.RawMessage `json:"mapping"`
+	}
+	if json.Unmarshal(arr[0], &probe) != nil {
+		return false
+	}
+	return len(probe.Mapping) > 0
+}
+
+func parseChatGPT(data []byte) (*ParsedConversation, error) {
+	var convos []chatGPTExport
+	if err := json.Unmarshal(data, &convos); err != nil {
+		return nil, fmt.Errorf("parsing ChatGPT JSON: %w", err)
+	}
+
+	conv := &ParsedConversation{
+		Format: FormatChatGPT,
+		Source: "chatgpt",
+	}
+
+	for _, c := range convos {
+		if conv.Title == "" {
+			conv.Title = c.Title
+		}
+		turns := flattenChatGPTMapping(c.Mapping)
+		conv.Turns = append(conv.Turns, turns...)
+	}
+
+	return conv, nil
+}
+
+// flattenChatGPTMapping walks the ChatGPT mapping tree to extract turns in order.
+func flattenChatGPTMapping(mapping map[string]chatGPTMappingNode) []Turn {
+	// Find root (no parent)
+	var rootID string
+	for id, node := range mapping {
+		if node.Parent == "" {
+			rootID = id
+			break
+		}
+	}
+	if rootID == "" {
+		return nil
+	}
+
+	var turns []Turn
+	var walk func(id string)
+	walk = func(id string) {
+		node, ok := mapping[id]
+		if !ok {
+			return
+		}
+		if node.Message != nil {
+			role := normalizeRole(node.Message.Author.Role)
+			if role == "user" || role == "assistant" {
+				content := extractChatGPTParts(node.Message.Content.Parts)
+				content = strings.TrimSpace(content)
+				if content != "" {
+					turns = append(turns, Turn{Role: role, Content: content})
+				}
+			}
+		}
+		for _, childID := range node.Children {
+			walk(childID)
+		}
+	}
+	walk(rootID)
+	return turns
+}
+
+func extractChatGPTParts(parts []any) string {
+	var texts []string
+	for _, p := range parts {
+		switch v := p.(type) {
+		case string:
+			texts = append(texts, v)
+		case map[string]any:
+			// Some parts are objects (images, etc.) — skip
+		}
+	}
+	return strings.Join(texts, "\n")
+}
+
+// --- Plain text ---
+
+func parsePlainText(data []byte) (*ParsedConversation, error) {
+	conv := &ParsedConversation{
+		Format: FormatPlainText,
+		Source: "plaintext",
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var currentRole string
+	var currentContent strings.Builder
+
+	flush := func() {
+		if currentRole != "" {
+			content := strings.TrimSpace(currentContent.String())
+			if content != "" {
+				conv.Turns = append(conv.Turns, Turn{Role: currentRole, Content: content})
+			}
+		}
+		currentContent.Reset()
+	}
+
+	for _, line := range lines {
+		if m := plainTextRoleMatch(line); m != "" {
+			flush()
+			currentRole = m
+			// Content after the "Role:" prefix
+			idx := strings.Index(line, ":")
+			rest := strings.TrimSpace(line[idx+1:])
+			if rest != "" {
+				currentContent.WriteString(rest)
+			}
+		} else {
+			if currentRole != "" {
+				if currentContent.Len() > 0 {
+					currentContent.WriteString("\n")
+				}
+				currentContent.WriteString(line)
+			}
+		}
+	}
+	flush()
+
+	return conv, nil
+}
+
+func plainTextRoleMatch(line string) string {
+	trimmed := strings.TrimSpace(line)
+	for _, prefix := range []string{"Human:", "User:"} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return "user"
+		}
+	}
+	if strings.HasPrefix(trimmed, "Assistant:") {
+		return "assistant"
+	}
+	return ""
+}
+
+// --- Markdown ---
+
+func parseMarkdown(data []byte) (*ParsedConversation, error) {
+	conv := &ParsedConversation{
+		Format: FormatMarkdown,
+		Source: "markdown",
+	}
+
+	// Treat the whole markdown as a single user turn
+	content := strings.TrimSpace(string(data))
+	if content != "" {
+		conv.Turns = append(conv.Turns, Turn{Role: "user", Content: content})
+	}
+
+	return conv, nil
+}
+
+// --- Helpers ---
+
+func normalizeRole(role string) string {
+	switch strings.ToLower(role) {
+	case "user", "human":
+		return "user"
+	case "assistant", "model", "bot", "grok", "chatgpt":
+		return "assistant"
+	case "system":
+		return "system"
+	default:
+		return role
+	}
+}

--- a/ingest/formats_test.go
+++ b/ingest/formats_test.go
@@ -1,0 +1,310 @@
+package ingest
+
+import (
+	"testing"
+)
+
+func TestDetectGrokFormat(t *testing.T) {
+	data := []byte(`[{"conversation_id":"abc123","title":"Test","create_time":"2024-01-01","turns":[{"author":{"role":"user"},"content":{"content_type":"text","parts":["hello"]}}]}]`)
+	got := Detect(data)
+	if got != FormatGrok {
+		t.Errorf("Detect() = %q, want %q", got, FormatGrok)
+	}
+}
+
+func TestDetectChatGPTFormat(t *testing.T) {
+	data := []byte(`[{"id":"abc","title":"Test","mapping":{"node1":{"id":"node1","parent":"","children":["node2"],"message":{"id":"msg1","author":{"role":"user"},"content":{"content_type":"text","parts":["hello"]}}},"node2":{"id":"node2","parent":"node1","children":[],"message":{"id":"msg2","author":{"role":"assistant"},"content":{"content_type":"text","parts":["hi there"]}}}}}]`)
+	got := Detect(data)
+	if got != FormatChatGPT {
+		t.Errorf("Detect() = %q, want %q", got, FormatChatGPT)
+	}
+}
+
+func TestDetectPlainText(t *testing.T) {
+	data := []byte("Human: How are you?\nAssistant: I'm good, thanks!")
+	got := Detect(data)
+	if got != FormatPlainText {
+		t.Errorf("Detect() = %q, want %q", got, FormatPlainText)
+	}
+}
+
+func TestDetectPlainTextUser(t *testing.T) {
+	data := []byte("User: How are you?\nAssistant: I'm good, thanks!")
+	got := Detect(data)
+	if got != FormatPlainText {
+		t.Errorf("Detect() = %q, want %q", got, FormatPlainText)
+	}
+}
+
+func TestDetectMarkdown(t *testing.T) {
+	data := []byte("# My Notes\n\nSome content here")
+	got := Detect(data)
+	if got != FormatMarkdown {
+		t.Errorf("Detect() = %q, want %q", got, FormatMarkdown)
+	}
+}
+
+func TestDetectUnknown(t *testing.T) {
+	data := []byte("just some random text without markers")
+	got := Detect(data)
+	if got != FormatUnknown {
+		t.Errorf("Detect() = %q, want %q", got, FormatUnknown)
+	}
+}
+
+func TestDetectEmpty(t *testing.T) {
+	got := Detect([]byte(""))
+	if got != FormatUnknown {
+		t.Errorf("Detect() = %q, want %q", got, FormatUnknown)
+	}
+}
+
+func TestParseGrok(t *testing.T) {
+	data := []byte(`[{
+		"conversation_id": "abc123",
+		"title": "Test Convo",
+		"create_time": "2024-01-01",
+		"turns": [
+			{"author": {"role": "user"}, "content": {"content_type": "text", "parts": ["we decided to use gRPC"]}},
+			{"author": {"role": "model"}, "content": {"content_type": "text", "parts": ["Good choice!"]}}
+		]
+	}]`)
+
+	conv, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	if conv.Format != FormatGrok {
+		t.Errorf("Format = %q, want %q", conv.Format, FormatGrok)
+	}
+	if conv.Source != "grok" {
+		t.Errorf("Source = %q, want %q", conv.Source, "grok")
+	}
+	if conv.Title != "Test Convo" {
+		t.Errorf("Title = %q, want %q", conv.Title, "Test Convo")
+	}
+	if len(conv.Turns) != 2 {
+		t.Fatalf("len(Turns) = %d, want 2", len(conv.Turns))
+	}
+	if conv.Turns[0].Role != "user" {
+		t.Errorf("Turn[0].Role = %q, want %q", conv.Turns[0].Role, "user")
+	}
+	if conv.Turns[0].Content != "we decided to use gRPC" {
+		t.Errorf("Turn[0].Content = %q, want %q", conv.Turns[0].Content, "we decided to use gRPC")
+	}
+	if conv.Turns[1].Role != "assistant" {
+		t.Errorf("Turn[1].Role = %q, want %q", conv.Turns[1].Role, "assistant")
+	}
+}
+
+func TestParseChatGPT(t *testing.T) {
+	data := []byte(`[{
+		"id": "conv1",
+		"title": "ChatGPT Test",
+		"mapping": {
+			"root": {
+				"id": "root",
+				"parent": "",
+				"children": ["msg1"],
+				"message": null
+			},
+			"msg1": {
+				"id": "msg1",
+				"parent": "root",
+				"children": ["msg2"],
+				"message": {
+					"id": "m1",
+					"author": {"role": "user"},
+					"content": {"content_type": "text", "parts": ["turns out the port was wrong"]}
+				}
+			},
+			"msg2": {
+				"id": "msg2",
+				"parent": "msg1",
+				"children": [],
+				"message": {
+					"id": "m2",
+					"author": {"role": "assistant"},
+					"content": {"content_type": "text", "parts": ["I see, let me help fix that"]}
+				}
+			}
+		}
+	}]`)
+
+	conv, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	if conv.Format != FormatChatGPT {
+		t.Errorf("Format = %q, want %q", conv.Format, FormatChatGPT)
+	}
+	if conv.Title != "ChatGPT Test" {
+		t.Errorf("Title = %q, want %q", conv.Title, "ChatGPT Test")
+	}
+	if len(conv.Turns) != 2 {
+		t.Fatalf("len(Turns) = %d, want 2", len(conv.Turns))
+	}
+	if conv.Turns[0].Content != "turns out the port was wrong" {
+		t.Errorf("Turn[0].Content = %q", conv.Turns[0].Content)
+	}
+}
+
+func TestParsePlainText(t *testing.T) {
+	data := []byte("Human: How are you?\nAssistant: I'm doing well.\nHuman: Great!")
+	conv, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	if conv.Format != FormatPlainText {
+		t.Errorf("Format = %q, want %q", conv.Format, FormatPlainText)
+	}
+	if len(conv.Turns) != 3 {
+		t.Fatalf("len(Turns) = %d, want 3", len(conv.Turns))
+	}
+	if conv.Turns[0].Role != "user" {
+		t.Errorf("Turn[0].Role = %q, want %q", conv.Turns[0].Role, "user")
+	}
+	if conv.Turns[1].Role != "assistant" {
+		t.Errorf("Turn[1].Role = %q, want %q", conv.Turns[1].Role, "assistant")
+	}
+}
+
+func TestExtractMemoriesDecision(t *testing.T) {
+	conv := &ParsedConversation{
+		Format: FormatGrok,
+		Source: "grok",
+		Turns: []Turn{
+			{Role: "user", Content: "we decided to use gRPC for the API"},
+		},
+	}
+
+	memories := ExtractMemories(conv)
+	if len(memories) == 0 {
+		t.Fatal("expected at least one extracted memory")
+	}
+
+	found := false
+	for _, m := range memories {
+		if m.Type == "decision" {
+			found = true
+			if m.Speaker != "j33p" {
+				t.Errorf("Speaker = %q, want %q", m.Speaker, "j33p")
+			}
+			if m.Source != "grok" {
+				t.Errorf("Source = %q, want %q", m.Source, "grok")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a 'decision' type memory for 'we decided to use gRPC'")
+	}
+}
+
+func TestExtractMemoriesLesson(t *testing.T) {
+	conv := &ParsedConversation{
+		Format: FormatChatGPT,
+		Source: "chatgpt",
+		Turns: []Turn{
+			{Role: "user", Content: "context"},
+			{Role: "assistant", Content: "context"},
+			{Role: "user", Content: "context"},
+			{Role: "assistant", Content: "turns out the port was wrong and that caused the connection failures"},
+		},
+	}
+
+	memories := ExtractMemories(conv)
+	found := false
+	for _, m := range memories {
+		if m.Type == "lesson" {
+			found = true
+			if m.Speaker != "chatgpt" {
+				t.Errorf("Speaker = %q, want %q", m.Speaker, "chatgpt")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a 'lesson' type memory for 'turns out the port was wrong'")
+	}
+}
+
+func TestExtractMemoriesPreference(t *testing.T) {
+	conv := &ParsedConversation{
+		Format: FormatPlainText,
+		Source: "plaintext",
+		Turns: []Turn{
+			{Role: "user", Content: "context"},
+			{Role: "user", Content: "context"},
+			{Role: "user", Content: "context"},
+			{Role: "user", Content: "I prefer using Go over Python for CLI tools"},
+		},
+	}
+
+	memories := ExtractMemories(conv)
+	found := false
+	for _, m := range memories {
+		if m.Type == "preference" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a 'preference' type memory for 'I prefer using Go'")
+	}
+}
+
+func TestExtractMemoriesProjectContext(t *testing.T) {
+	conv := &ParsedConversation{
+		Format: FormatPlainText,
+		Source: "plaintext",
+		Turns: []Turn{
+			{Role: "user", Content: "Help me set up a new project"},
+			{Role: "assistant", Content: "Sure, what kind of project?"},
+		},
+	}
+
+	memories := ExtractMemories(conv)
+	contextCount := 0
+	for _, m := range memories {
+		if m.Type == "project_context" {
+			contextCount++
+		}
+	}
+	if contextCount != 2 {
+		t.Errorf("expected 2 project_context memories for first 2 turns, got %d", contextCount)
+	}
+}
+
+func TestExtractMemoriesEmpty(t *testing.T) {
+	memories := ExtractMemories(nil)
+	if memories != nil {
+		t.Errorf("expected nil for nil conversation, got %d memories", len(memories))
+	}
+
+	memories = ExtractMemories(&ParsedConversation{})
+	if memories != nil {
+		t.Errorf("expected nil for empty conversation, got %d memories", len(memories))
+	}
+}
+
+func TestParseMalformedJSON(t *testing.T) {
+	_, err := Parse([]byte(`{bad json`))
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestParseInputTooLarge(t *testing.T) {
+	data := make([]byte, MaxInputSize+1)
+	for i := range data {
+		data[i] = 'a'
+	}
+	_, err := Parse(data)
+	if err == nil {
+		t.Error("expected error for oversized input")
+	}
+}

--- a/ingest/hash.go
+++ b/ingest/hash.go
@@ -1,0 +1,14 @@
+package ingest
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+// contentHash returns the first 16 hex chars of sha256(trimmed content).
+// Compatible with tools.contentHash.
+func contentHash(content string) string {
+	h := sha256.Sum256([]byte(strings.TrimSpace(content)))
+	return fmt.Sprintf("%x", h[:8])
+}

--- a/server/server.go
+++ b/server/server.go
@@ -137,6 +137,9 @@ linkMemories := &tools.LinkMemories{DB: s.dbClient}
 
 	unlinkMemories := &tools.UnlinkMemories{DB: s.dbClient}
 	s.mcp.AddTool(unlinkMemories.Tool(), unlinkMemories.Handle)
+
+	ingestConv := &tools.IngestConversation{DB: s.dbClient, Embedder: s.embedder}
+	s.mcp.AddTool(ingestConv.Tool(), ingestConv.Handle)
 }
 
 func (s *Server) registerResources() {

--- a/tools/ingest.go
+++ b/tools/ingest.go
@@ -1,0 +1,134 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/j33pguy/claude-memory/classify"
+	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/claude-memory/ingest"
+)
+
+// IngestConversation imports a conversation export into memory.
+type IngestConversation struct {
+	DB       *db.Client
+	Embedder embeddings.Provider
+}
+
+// Tool returns the MCP tool definition for ingest_conversation.
+func (t *IngestConversation) Tool() mcp.Tool {
+	return mcp.NewTool("ingest_conversation",
+		mcp.WithDescription("Import a conversation export (Grok, ChatGPT, or plain text) into memory. Auto-detects format and extracts decisions, lessons, preferences, and context."),
+		mcp.WithString("content", mcp.Required(), mcp.Description("Raw conversation text or JSON export")),
+		mcp.WithString("source", mcp.Description("Source format: grok, chatgpt, plaintext, or auto (default: auto)")),
+		mcp.WithString("project", mcp.Description("Associate all memories with this project")),
+		mcp.WithBoolean("dry_run", mcp.Description("If true, return what would be imported without storing (default: false)")),
+	)
+}
+
+// Handle processes an ingest_conversation tool call.
+func (t *IngestConversation) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	content, err := request.RequireString("content")
+	if err != nil {
+		return mcp.NewToolResultError("content is required"), nil
+	}
+
+	project := request.GetString("project", "")
+	dryRun := request.GetBool("dry_run", false)
+
+	data := []byte(content)
+	conv, err := ingest.Parse(data)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("parse error: %v", err)), nil
+	}
+
+	candidates := ingest.ExtractMemories(conv)
+
+	dedup := &ingest.Deduplicator{DB: t.DB, Embedder: t.Embedder}
+	kept, skipped, err := dedup.Filter(ctx, candidates)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("dedup error: %v", err)), nil
+	}
+
+	if dryRun {
+		type preview struct {
+			Type    string `json:"type"`
+			Summary string `json:"summary"`
+			Speaker string `json:"speaker"`
+		}
+		var previews []preview
+		for _, em := range kept {
+			previews = append(previews, preview{
+				Type:    em.Type,
+				Summary: em.Summary,
+				Speaker: em.Speaker,
+			})
+		}
+		result := struct {
+			Format    string    `json:"format"`
+			WouldImport int    `json:"would_import"`
+			WouldSkip   int    `json:"would_skip"`
+			Memories  []preview `json:"memories"`
+		}{
+			Format:      string(conv.Format),
+			WouldImport: len(kept),
+			WouldSkip:   skipped,
+			Memories:    previews,
+		}
+		out, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(out)), nil
+	}
+
+	var imported int
+	var ids []string
+	for _, em := range kept {
+		c := classify.Infer(em.Content)
+		embedding, err := t.Embedder.Embed(ctx, em.Content)
+		if err != nil {
+			slog.Error("embedding failed during ingest", "error", err)
+			continue
+		}
+
+		mem := &db.Memory{
+			Content:    em.Content,
+			Summary:    em.Summary,
+			Embedding:  embedding,
+			Project:    project,
+			Type:       em.Type,
+			Source:     em.Source,
+			Speaker:    em.Speaker,
+			Area:       c.Area,
+			SubArea:    c.SubArea,
+			TokenCount: len(em.Content) / 4,
+		}
+
+		saved, err := t.DB.SaveMemory(mem)
+		if err != nil {
+			slog.Error("save failed during ingest", "error", err)
+			continue
+		}
+
+		tags := append(em.Tags, "speaker:"+em.Speaker)
+		if c.Area != "" {
+			tags = append(tags, "area:"+c.Area)
+		}
+		if c.SubArea != "" {
+			tags = append(tags, "sub_area:"+c.SubArea)
+		}
+		if err := t.DB.SetTags(saved.ID, tags); err != nil {
+			slog.Error("set tags failed during ingest", "error", err)
+		}
+
+		imported++
+		ids = append(ids, saved.ID)
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf(
+		"Ingested %d memories from %s conversation (skipped %d duplicates). IDs: %v",
+		imported, conv.Format, skipped, ids,
+	)), nil
+}

--- a/web/server.go
+++ b/web/server.go
@@ -5,15 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/j33pguy/claude-memory/classify"
 	"github.com/j33pguy/claude-memory/db"
 	"github.com/j33pguy/claude-memory/embeddings"
 	"github.com/j33pguy/claude-memory/patterns"
+"github.com/j33pguy/claude-memory/ingest"
 )
 
 const pageSize = 30
@@ -32,6 +35,10 @@ func RegisterRoutes(mux *http.ServeMux, dbClient *db.Client, embedder embeddings
 	mux.HandleFunc("GET /graph", h.graphPage)
 
 	mux.HandleFunc("GET /patterns", h.patternsPage)
+// Ingest
+	mux.HandleFunc("GET /ingest", h.ingestPage)
+	mux.HandleFunc("POST /ingest", h.handleIngest)
+	mux.HandleFunc("POST /api/ingest/detect", h.handleDetectFormat)
 
 	// API endpoints
 	mux.HandleFunc("GET /api/memories", h.apiMemories)
@@ -892,6 +899,127 @@ func channelBadge(s string) string {
 
 func isTopicTag(s string) bool {
 	return strings.HasPrefix(s, "topic:")
+}
+
+// --- Ingest handlers ---
+
+func (h *handler) ingestPage(w http.ResponseWriter, r *http.Request) {
+	h.render(w, "base", map[string]string{"Nav": "ingest"})
+}
+
+type ingestResponse struct {
+	Imported int              `json:"imported"`
+	Skipped  int              `json:"skipped"`
+	Memories []ingestMemoryRef `json:"memories,omitempty"`
+	Error    string           `json:"error,omitempty"`
+}
+
+type ingestMemoryRef struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Summary string `json:"summary"`
+}
+
+func (h *handler) handleIngest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, ingest.MaxInputSize+1))
+	if err != nil {
+		json.NewEncoder(w).Encode(ingestResponse{Error: "failed to read body"})
+		return
+	}
+	if len(body) > ingest.MaxInputSize {
+		json.NewEncoder(w).Encode(ingestResponse{Error: "input too large (max 10MB)"})
+		return
+	}
+
+	conv, err := ingest.Parse(body)
+	if err != nil {
+		json.NewEncoder(w).Encode(ingestResponse{Error: fmt.Sprintf("parse error: %v", err)})
+		return
+	}
+
+	candidates := ingest.ExtractMemories(conv)
+
+	dedup := &ingest.Deduplicator{DB: h.db, Embedder: h.embedder}
+	kept, skipped, err := dedup.Filter(r.Context(), candidates)
+	if err != nil {
+		json.NewEncoder(w).Encode(ingestResponse{Error: fmt.Sprintf("dedup error: %v", err)})
+		return
+	}
+
+	resp := ingestResponse{Skipped: skipped}
+	for _, em := range kept {
+		c := classify.Infer(em.Content)
+		embedding, err := h.embedder.Embed(r.Context(), em.Content)
+		if err != nil {
+			h.logger.Error("embedding failed during ingest", "error", err)
+			continue
+		}
+
+		mem := &db.Memory{
+			Content:    em.Content,
+			Summary:    em.Summary,
+			Embedding:  embedding,
+			Type:       em.Type,
+			Source:     em.Source,
+			Speaker:    em.Speaker,
+			Area:       c.Area,
+			SubArea:    c.SubArea,
+			TokenCount: len(em.Content) / 4,
+		}
+
+		saved, err := h.db.SaveMemory(mem)
+		if err != nil {
+			h.logger.Error("save failed during ingest", "error", err)
+			continue
+		}
+
+		tags := append(em.Tags, "speaker:"+em.Speaker)
+		if c.Area != "" {
+			tags = append(tags, "area:"+c.Area)
+		}
+		if c.SubArea != "" {
+			tags = append(tags, "sub_area:"+c.SubArea)
+		}
+		if err := h.db.SetTags(saved.ID, tags); err != nil {
+			h.logger.Error("set tags failed during ingest", "error", err)
+		}
+
+		resp.Imported++
+		resp.Memories = append(resp.Memories, ingestMemoryRef{
+			ID:      saved.ID,
+			Type:    em.Type,
+			Summary: em.Summary,
+		})
+	}
+
+	json.NewEncoder(w).Encode(resp)
+}
+
+type detectResponse struct {
+	Format string `json:"format"`
+	Turns  int    `json:"turns,omitempty"`
+}
+
+func (h *handler) handleDetectFormat(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, ingest.MaxInputSize+1))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	format := ingest.Detect(body)
+	resp := detectResponse{Format: string(format)}
+
+	// Try to parse to get turn count
+	if conv, err := ingest.Parse(body); err == nil {
+		resp.Turns = len(conv.Turns)
+	}
+
+	json.NewEncoder(w).Encode(resp)
 }
 
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -317,6 +317,8 @@
             <a href="/graph" class="nav-link{{if eq .Nav "graph"}} active{{end}}">Graph</a>
             <a href="/conversations" class="nav-link{{if eq .Nav "conversations"}} active{{end}}">Conversations</a>
 <a href="/patterns" class="nav-link{{if eq .Nav "patterns"}} active{{end}}">Patterns</a>
+<a href="/ingest" class="nav-link{{if eq .Nav "ingest"}} active{{end}}">Import</a>
+            <span class="nav-link disabled">Graph</span>
         </div>
     </nav>
     <main class="container">

--- a/web/templates/ingest.html
+++ b/web/templates/ingest.html
@@ -1,0 +1,189 @@
+{{define "title"}}import — memory{{end}}
+{{define "content"}}
+<style>
+    .drop-zone {
+        border: 2px dashed var(--border);
+        border-radius: 12px;
+        padding: 48px 24px;
+        text-align: center;
+        cursor: pointer;
+        transition: all 0.2s;
+        margin-bottom: 16px;
+    }
+    .drop-zone:hover, .drop-zone.dragover {
+        border-color: var(--accent);
+        background: rgba(99,102,241,0.05);
+    }
+    .drop-zone-text {
+        color: var(--text-muted);
+        font-size: 15px;
+        margin-bottom: 8px;
+    }
+    .drop-zone-hint {
+        color: var(--text-muted);
+        font-size: 12px;
+        opacity: 0.7;
+    }
+    .ingest-results {
+        margin-top: 16px;
+    }
+    .ingest-summary {
+        padding: 12px 16px;
+        border-radius: 8px;
+        background: rgba(16,185,129,0.1);
+        border: 1px solid rgba(16,185,129,0.2);
+        color: var(--green);
+        font-size: 14px;
+        margin-bottom: 12px;
+    }
+    .ingest-summary.error {
+        background: rgba(239,68,68,0.1);
+        border-color: rgba(239,68,68,0.2);
+        color: var(--red);
+    }
+    .ingest-memory-list {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .ingest-memory-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        font-size: 13px;
+        border-bottom: 1px solid var(--border);
+    }
+    .format-badge {
+        padding: 4px 10px;
+        border-radius: 6px;
+        font-size: 12px;
+        font-weight: 500;
+        background: rgba(99,102,241,0.12);
+        color: var(--accent);
+    }
+    .paste-section { margin-top: 16px; }
+    .action-row { display: flex; gap: 8px; margin-top: 12px; align-items: center; }
+</style>
+
+<div style="margin-bottom: 24px;">
+    <h2 style="font-size: 20px; font-weight: 600; margin-bottom: 4px;">Import Conversations</h2>
+    <p style="font-size: 13px; color: var(--text-muted);">Drop a Grok or ChatGPT export file, or paste text below</p>
+</div>
+
+<div class="drop-zone" id="dropZone" onclick="document.getElementById('fileInput').click()">
+    <div class="drop-zone-text">Drop a conversation export file here</div>
+    <div class="drop-zone-hint">Supports Grok JSON, ChatGPT JSON, and plain text</div>
+    <input type="file" id="fileInput" accept=".json,.txt,.md" style="display:none">
+</div>
+
+<div id="formatDetected"></div>
+
+<div class="paste-section">
+    <label for="pasteArea">Or paste conversation text</label>
+    <textarea id="pasteArea" class="textarea" rows="8" placeholder="Paste Grok/ChatGPT JSON export or plain text conversation here..."></textarea>
+</div>
+
+<div class="action-row">
+    <button class="btn" id="detectBtn" onclick="detectFormat()">Detect Format</button>
+    <button class="btn btn-primary" id="importBtn" onclick="importConversation()">Import</button>
+    <span class="htmx-indicator" id="loadingIndicator"><span class="spinner"></span> Analyzing conversation…</span>
+</div>
+
+<div id="results" class="ingest-results"></div>
+
+<script>
+const dropZone = document.getElementById('dropZone');
+const fileInput = document.getElementById('fileInput');
+const pasteArea = document.getElementById('pasteArea');
+let currentData = null;
+
+dropZone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+});
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+dropZone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+    const file = e.dataTransfer.files[0];
+    if (file) readFile(file);
+});
+fileInput.addEventListener('change', () => {
+    if (fileInput.files[0]) readFile(fileInput.files[0]);
+});
+
+function readFile(file) {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+        pasteArea.value = e.target.result;
+        currentData = e.target.result;
+        dropZone.querySelector('.drop-zone-text').textContent = file.name;
+    };
+    reader.readAsText(file);
+}
+
+function getContent() {
+    return pasteArea.value || currentData || '';
+}
+
+function detectFormat() {
+    const content = getContent();
+    if (!content) return;
+    fetch('/api/ingest/detect', {
+        method: 'POST',
+        headers: {'Content-Type': 'text/plain'},
+        body: content
+    })
+    .then(r => r.json())
+    .then(data => {
+        document.getElementById('formatDetected').innerHTML =
+            '<div style="margin:8px 0"><span class="format-badge">Detected: ' + data.format + '</span>' +
+            (data.turns ? ' <span style="color:var(--text-muted);font-size:12px">' + data.turns + ' turns</span>' : '') +
+            '</div>';
+    })
+    .catch(() => {
+        document.getElementById('formatDetected').innerHTML =
+            '<div class="ingest-summary error">Could not detect format</div>';
+    });
+}
+
+function importConversation() {
+    const content = getContent();
+    if (!content) return;
+    const indicator = document.getElementById('loadingIndicator');
+    indicator.style.display = 'inline-flex';
+
+    fetch('/ingest', {
+        method: 'POST',
+        headers: {'Content-Type': 'text/plain'},
+        body: content
+    })
+    .then(r => r.json())
+    .then(data => {
+        indicator.style.display = 'none';
+        let html = '';
+        if (data.error) {
+            html = '<div class="ingest-summary error">' + data.error + '</div>';
+        } else {
+            html = '<div class="ingest-summary">Imported ' + data.imported + ' memories · Skipped ' + data.skipped + ' duplicates</div>';
+            if (data.memories && data.memories.length > 0) {
+                html += '<div class="card"><div class="ingest-memory-list">';
+                data.memories.forEach(m => {
+                    html += '<div class="ingest-memory-item">' +
+                        '<span class="badge badge-accent">' + m.type + '</span>' +
+                        '<span>' + m.summary + '</span></div>';
+                });
+                html += '</div></div>';
+            }
+        }
+        document.getElementById('results').innerHTML = html;
+    })
+    .catch(() => {
+        indicator.style.display = 'none';
+        document.getElementById('results').innerHTML =
+            '<div class="ingest-summary error">Import failed</div>';
+    });
+}
+</script>
+{{end}}


### PR DESCRIPTION
## Summary
- Adds `ingest/` package with auto-detection and parsing of Grok JSON, ChatGPT JSON, and plain text (Human:/Assistant:) conversation formats
- Extracts meaningful memories (decisions, lessons, preferences, project context) using keyword heuristics — no LLM calls
- Content-hash deduplication prevents importing duplicates
- New `/ingest` web UI page with drag-and-drop upload and paste support
- New `ingest_conversation` MCP tool with `dry_run` support
- 17 tests covering detection, parsing, extraction, and edge cases

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./ingest/...` — 17 tests pass
- [x] `go test ./tools/...` — existing tests still pass
- [ ] Manual: upload a Grok JSON export via /ingest web UI
- [ ] Manual: paste a ChatGPT JSON export and verify detection + import
- [ ] Manual: test plain text with Human:/Assistant: markers
- [ ] Manual: verify `ingest_conversation` MCP tool with `dry_run: true`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)