### PR TITLE
feat: add 'state' memory type for current infrastructure state

### DIFF
--- a/tools/recall.go
+++ b/tools/recall.go
@@ -26,7 +26,7 @@ func (r *Recall) Tool() mcp.Tool {
 		mcp.WithArray("projects", mcp.Description("Filter by multiple namespaces — results from any match (e.g. ['agent:dinesh','crew:shared'])"), mcp.WithStringItems()),
 		mcp.WithString("type",
 			mcp.Description("Filter by memory type"),
-			mcp.Enum("memory", "incident", "lesson", "decision", "project_context", "conversation", "audit", "runbook", "preference", "context", "security"),
+			mcp.Enum("memory", "incident", "lesson", "decision", "project_context", "conversation", "audit", "runbook", "preference", "context", "security", "state"),
 		),
 		mcp.WithArray("tags", mcp.Description("Filter by tags (any match)"), mcp.WithStringItems()),
 		mcp.WithNumber("top_k", mcp.Description("Number of results to return (default 5)")),

--- a/tools/remember.go
+++ b/tools/remember.go
@@ -29,7 +29,7 @@ func (r *Remember) Tool() mcp.Tool {
 		mcp.WithString("project", mcp.Required(), mcp.Description("Project name (e.g. 'iac', 'famtask', 'global')")),
 		mcp.WithString("type",
 			mcp.Description("Memory type"),
-			mcp.Enum("memory", "incident", "lesson", "decision", "project_context", "conversation", "audit", "runbook", "preference", "context", "security"),
+			mcp.Enum("memory", "incident", "lesson", "decision", "project_context", "conversation", "audit", "runbook", "preference", "context", "security", "state"),
 		),
 		mcp.WithString("summary", mcp.Description("Brief one-line summary of the memory")),
 		mcp.WithArray("tags", mcp.Description("Tags for categorization"), mcp.WithStringItems()),
@@ -43,7 +43,7 @@ func (r *Remember) Tool() mcp.Tool {
 			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
 		),
 		mcp.WithString("sub_area",
-			mcp.Description("Sub-domain within area. Examples — work: power-platform, fabric, power-bi, sharepoint, teams, azure, td-synnex; homelab: proxmox, networking, security, dns, monitoring, storage, iac, vault, traefik, authentik, lancache; project: claude-memory, distify, labctl, vault-unsealer, iac; home: lego, gaming, streaming, media; family: kids, spouse, schedule"),
+			mcp.Description("Sub-domain within area (e.g. unifi-vlans, unifi-switches, pihole-ha, vault-cluster). For type=state: use a specific component name so current state is queryable by sub_area. Examples — work: power-platform, fabric, power-bi, sharepoint, teams, azure, td-synnex; homelab: proxmox, networking, security, dns, monitoring, storage, iac, vault, traefik, authentik, lancache; project: claude-memory, distify, labctl, vault-unsealer, iac; home: lego, gaming, streaming, media; family: kids, spouse, schedule"),
 		),
 	)
 }


### PR DESCRIPTION
## Summary
Adds a dedicated `state` type to the memory type enum.

## Problem
`runbook` was being used for both procedural docs (how to do something) and current state snapshots (what something is right now). This conflates two very different things and makes ranking unreliable.

## Solution
New `state` type specifically for current-state snapshots of hardware, network config, and services.

## Priority hierarchy in recall
```
state       → current config (highest — what is it right now?)
incident    → recent problems/changes
decision    → deliberate config decisions  
lesson      → lessons learned
runbook     → procedural docs
conversation → historical logs (lowest)
```

## Usage
```json
{
  "type": "state",
  "area": "homelab",
  "sub_area": "unifi-switches",
  "content": "CURRENT STATE - UniFi Switches..."
}
```

Query with: `POST /recall {"type": "state", "area": "homelab", "sub_area": "unifi-switches"}`