### PR TITLE
refactor: rename to MAGI (Multi-Agent Graph Intelligence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Build binary
-        run: go build -o /tmp/claude-memory-new .
+        run: go build -o /tmp/magi-new .
 
       - name: Get deploy key from Vault
         env:
@@ -60,24 +60,24 @@ jobs:
       - name: Deploy binary to memory01
         run: |
           scp -i /tmp/deploy_key -o StrictHostKeyChecking=no \
-            /tmp/claude-memory-new ansible@10.5.5.40:/tmp/claude-memory-new
+            /tmp/magi-new ansible@10.5.5.40:/tmp/magi-new
           ssh -i /tmp/deploy_key -o StrictHostKeyChecking=no \
             ansible@10.5.5.40 \
-            'sudo /usr/bin/install -m 755 /tmp/claude-memory-new /opt/claude-memory/bin/claude-memory && rm -f /tmp/claude-memory-new'
+            'sudo /usr/bin/install -m 755 /tmp/magi-new /opt/magi/bin/magi && rm -f /tmp/magi-new'
 
       - name: Restart service on memory01
         run: |
           ssh -i /tmp/deploy_key -o StrictHostKeyChecking=no \
             ansible@10.5.5.40 \
-            'sudo systemctl restart claude-memory'
+            'sudo systemctl restart magi'
 
       - name: Health check
         run: |
           sleep 4
           ssh -i /tmp/deploy_key -o StrictHostKeyChecking=no \
             ansible@10.5.5.40 \
-            'status=$(sudo systemctl is-active claude-memory); echo "claude-memory is $status"; [ "$status" = "active" ]'
+            'status=$(sudo systemctl is-active magi); echo "magi is $status"; [ "$status" = "active" ]'
 
       - name: Cleanup
         if: always()
-        run: rm -f /tmp/deploy_key /tmp/claude-memory-new
+        run: rm -f /tmp/deploy_key /tmp/magi-new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
-# claude-memory — RAG-based MCP Memory Server
+# magi — RAG-based MCP Memory Server
 
 Go MCP server that provides semantic memory for Claude Code using Turso (distributed libSQL with vector search) and local ONNX embeddings (all-MiniLM-L6-v2).
 
 ## Architecture
 
 ```
-Claude Code (stdio) → claude-memory (Go binary)
+Claude Code (stdio) → magi (Go binary)
     → Local ONNX embeddings (all-MiniLM-L6-v2, 384 dims)
     → Embedded SQLite replica (fast reads) ↔ Turso Cloud DB (sync)
 ```
@@ -38,11 +38,11 @@ brew install onnxruntime   # macOS
 ## Environment Variables
 
 ```
-TURSO_URL=libsql://claude-memory-<user>.turso.io
+TURSO_URL=libsql://magi-<user>.turso.io
 TURSO_AUTH_TOKEN=<token>
-CLAUDE_MEMORY_REPLICA_PATH=~/.claude/memory.db
-CLAUDE_MEMORY_SYNC_INTERVAL=60
-CLAUDE_MEMORY_MODEL_DIR=~/.claude/models
+MAGI_REPLICA_PATH=~/.magi.db
+MAGI_SYNC_INTERVAL=60
+MAGI_MODEL_DIR=~/.claude/models
 ONNXRUNTIME_LIB=/opt/homebrew/lib/libonnxruntime.dylib  # override auto-detect
 ```
 
@@ -57,7 +57,7 @@ make test     # Run tests
 ## Claude Code Integration
 
 ```bash
-claude mcp add -s user claude-memory -- claude-memory
+claude mcp add -s user magi -- magi
 ```
 
 ## MCP Tools

--- a/CONVERSATION_SYNC_PLAN.md
+++ b/CONVERSATION_SYNC_PLAN.md
@@ -23,7 +23,7 @@ We need a **conversation layer**: recent, searchable, cross-channel context.
 
 ```
 Webchat session ──┐                                ┌── Webchat session
-Discord session ───┼──→ claude-memory HTTP API ←────┤── Discord session  
+Discord session ───┼──→ magi HTTP API ←────┤── Discord session  
 Future channels ──┘         (memory01)              └── Claude Code (MCP)
                                   │
                               Turso cloud
@@ -52,7 +52,7 @@ New memory type: `conversation`
     "started_at": "2026-03-26T17:00:00Z",
     "ended_at": "2026-03-26T17:45:00Z",
     "turn_count": 12,
-    "topics": ["claude-memory", "conversation sync", "deployment"]
+    "topics": ["magi", "conversation sync", "deployment"]
   },
   "created_at": "2026-03-26T17:45:00Z",
   "source_machine": "homelab"
@@ -82,19 +82,19 @@ Start with **option B** (heartbeat) — zero infrastructure changes, ships fast.
 ```
 After significant conversations (5+ turns since last sync):
 - Summarize key topics, decisions, questions asked, anything to remember
-- POST to claude-memory /remember with type=conversation, tag=channel:discord or channel:webchat
+- POST to magi /remember with type=conversation, tag=channel:discord or channel:webchat
 - Update heartbeat-state.json with last_conversation_sync timestamp
 ```
 
 ### 1.2 — Context injection at session start
 
-At the start of each main session (webchat), I query claude-memory for recent conversations:
+At the start of each main session (webchat), I query magi for recent conversations:
 - `POST /recall` with query: "recent conversations cross-channel" + time filter
 - Inject as context: "In our last Discord conversation (2h ago), we discussed X, Y, Z"
 
 **AGENTS.md addition** (Every Session checklist):
 ```
-5. Query claude-memory for recent cross-channel conversations (last 24h)
+5. Query magi for recent cross-channel conversations (last 24h)
    - If any found: brief mental note before responding
 ```
 
@@ -102,7 +102,7 @@ At the start of each main session (webchat), I query claude-memory for recent co
 
 Currently blocked by group policy. Since it's just us:
 - Option A: OpenClaw config whitelist for guild `1466843154182574134` → load MEMORY.md
-- Option B: Don't touch MEMORY.md in Discord, rely entirely on claude-memory queries
+- Option B: Don't touch MEMORY.md in Discord, rely entirely on magi queries
 - **Recommendation: Option B** — cleaner, more scalable, works for any future channel
 
 ---
@@ -135,15 +135,15 @@ When I write a summary, it includes:
 Channel: discord
 Time: 2026-03-26 17:36 EDT
 Duration: ~20 min, 8 turns
-Topics: conversation sync feature, claude-memory deployment, cross-channel memory
-Key decisions: build session summary pipeline, add /conversations endpoint to claude-memory
+Topics: conversation sync feature, magi deployment, cross-channel memory
+Key decisions: build session summary pipeline, add /conversations endpoint to magi
 Action items: j33p wants full continuity across webchat/discord/future channels
 Notable: j33p emphasized "talk to you wherever, remember everything" as core requirement
 ```
 
 This is semantically rich enough that future recall works well:
 - "what did j33p say about memory?" → finds this
-- "what did we decide about claude-memory?" → finds this
+- "what did we decide about magi?" → finds this
 - "any action items from yesterday?" → finds this
 
 ---
@@ -161,8 +161,8 @@ Trade-off: more storage, more API calls to write, but dramatically better recall
 
 Architecture:
 - OpenClaw writes each turn to a local queue
-- Background worker batches queue → claude-memory in bulk
-- claude-memory chunks and embeds
+- Background worker batches queue → magi in bulk
+- magi chunks and embeds
 - Recall returns ranked turns by semantic similarity
 
 This is the "full memory" end state.
@@ -173,7 +173,7 @@ This is the "full memory" end state.
 
 Right now OpenClaw has:
 - Group chat policy blocking MEMORY.md (security)
-- No mechanism to tell claude-memory "this is j33p talking"
+- No mechanism to tell magi "this is j33p talking"
 
 Phase 4: verified identity tag on memories/conversations
 - In direct chats with j33p (verified by channel + user ID): tag `identity:j33p`
@@ -190,16 +190,16 @@ security risk if j33p ever adds someone else to the server.
 
 ### Now (no code changes)
 1. Add conversation sync to HEARTBEAT.md
-2. Add claude-memory recall to AGENTS.md session startup checklist
+2. Add magi recall to AGENTS.md session startup checklist
 3. Write first batch of conversation summaries manually to bootstrap
 
-### Soon (claude-memory v0.5)
+### Soon (magi v0.5)
 4. Add `/conversations` endpoints to HTTP API
 5. Add `store_conversation` / `recall_conversations` MCP tools  
 6. gRPC-ify (Issue #5 already open)
 7. Deploy to memory01 (Issue #1)
 
-### Later (claude-memory v0.6)
+### Later (magi v0.6)
 8. Per-turn indexing with chunking
 9. OpenClaw channel identity tags
 10. Session log watcher (v0.4, already planned)
@@ -211,21 +211,21 @@ security risk if j33p ever adds someone else to the server.
 1. **[v0.5] Cross-channel conversation sync** — `/conversations` endpoints + MCP tools
 2. **[v0.5] Conversation summary schema** — define the storage format
 3. **[bootstrap] Seed initial conversation history** — manual backfill from current sessions
-4. **[openclaw] Discord MEMORY.md policy** — evaluate whitelist vs claude-memory-only approach
+4. **[openclaw] Discord MEMORY.md policy** — evaluate whitelist vs magi-only approach
 
 ---
 
 ## Quick Win (Do Now Without Deployment)
 
-Even before claude-memory is deployed on memory01, I can start writing conversation 
+Even before magi is deployed on memory01, I can start writing conversation 
 summaries *as memories* using the existing `/remember` endpoint once it's running.
 
 The separation into a dedicated `/conversations` API can come later — the data model 
 (type=conversation + tags) works with the existing schema today.
 
 **Day 1 plan:**
-1. Deploy claude-memory to memory01 (unblock Issue #1)
-2. Add to HEARTBEAT.md: "summarize this session, POST to claude-memory"
+1. Deploy magi to memory01 (unblock Issue #1)
+2. Add to HEARTBEAT.md: "summarize this session, POST to magi"
 3. Add to AGENTS.md: "on startup, recall recent conversations"
 4. Start accumulating conversation history
 5. Open Issue for proper /conversations API

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build install test clean import fmt lint proto
 
-BINARY   := claude-memory
-IMPORT   := claude-memory-import
+BINARY   := magi
+IMPORT   := magi-import
 GOFLAGS  := -trimpath
 CGO      := 1
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# claude-memory
+# magi
 
 > Personal AI memory server. Semantic search, cross-channel conversation sync, and behavioral pattern learning for Claude.
 
 ## What is this?
 
-Claude has no persistent memory across sessions or channels. Every conversation starts from scratch — context vanishes the moment a session ends. **claude-memory** fixes that.
+Claude has no persistent memory across sessions or channels. Every conversation starts from scratch — context vanishes the moment a session ends. **magi** fixes that.
 
 It's a self-hosted Go server that gives Claude (and any other AI agent) a persistent, searchable memory layer. Memories are stored as vector embeddings in [Turso](https://turso.tech) (distributed libSQL), with a local embedded replica for fast offline reads. Embeddings are generated locally using ONNX Runtime (all-MiniLM-L6-v2, 384 dimensions) — no OpenAI API key, no cloud embedding service, no data leaving your machine.
 
-claude-memory exposes four interfaces: **MCP** (for Claude Code via stdio), **gRPC** (for services), **HTTP/JSON** (via grpc-gateway), and a **web UI** (for humans). Whether Claude is talking to you in a terminal, a Discord bot, or a web chat — it remembers.
+magi exposes four interfaces: **MCP** (for Claude Code via stdio), **gRPC** (for services), **HTTP/JSON** (via grpc-gateway), and a **web UI** (for humans). Whether Claude is talking to you in a terminal, a Discord bot, or a web chat — it remembers.
 
 ## Features
 
@@ -91,17 +91,17 @@ Heuristic-based analysis that detects patterns from your memory corpus:
 ### Build
 
 ```bash
-git clone https://github.com/j33pguy/claude-memory
-cd claude-memory
+git clone https://github.com/j33pguy/magi
+cd magi
 CGO_ENABLED=1 make build
 ```
 
 ### Configure
 
 ```bash
-export TURSO_URL=libsql://claude-memory-<you>.turso.io
+export TURSO_URL=libsql://magi-<you>.turso.io
 export TURSO_AUTH_TOKEN=<token>
-export CLAUDE_MEMORY_API_TOKEN=<your-bearer-token>  # optional, unset = no auth
+export MAGI_API_TOKEN=<your-bearer-token>  # optional, unset = no auth
 ```
 
 See [Environment Variables](#environment-variables) for the full list.
@@ -110,16 +110,17 @@ See [Environment Variables](#environment-variables) for the full list.
 
 ```bash
 # MCP mode (stdio) — for Claude Code
-./bin/claude-memory
+./bin/magi
 
 # HTTP-only mode — for server deployments
-./bin/claude-memory --http-only
+./bin/magi --http-only
 ```
 
 ### Claude Code MCP Setup
 
 ```bash
-claude mcp add -s user claude-memory -- claude-memory
+# Via MCP (Claude Code, Cursor, etc)
+claude mcp add -s user magi -- magi
 ```
 
 Or add to your MCP config manually:
@@ -127,10 +128,10 @@ Or add to your MCP config manually:
 ```json
 {
   "mcpServers": {
-    "claude-memory": {
-      "command": "/usr/local/bin/claude-memory",
+    "magi": {
+      "command": "/usr/local/bin/magi",
       "env": {
-        "TURSO_URL": "libsql://claude-memory-<you>.turso.io",
+        "TURSO_URL": "libsql://magi-<you>.turso.io",
         "TURSO_AUTH_TOKEN": "<token>"
       }
     }
@@ -142,7 +143,7 @@ Or add to your MCP config manually:
 
 ```
 ┌─────────────────┐   stdio    ┌───────────────────────────────────────────┐
-│  Claude Code    │───────────▶│              claude-memory                │
+│  Claude Code    │───────────▶│              magi                │
 └─────────────────┘            │                                           │
 ┌─────────────────┐   gRPC    │  ┌─────────┐  ┌────────────────────────┐  │
 │  gRPC clients   │──:8300───▶│  │  Tools   │  │  ONNX Runtime          │  │
@@ -169,14 +170,14 @@ See [docs/architecture.md](docs/architecture.md) for detailed data flow.
 |----------|---------|-------------|
 | `TURSO_URL` | _(required)_ | libSQL database URL |
 | `TURSO_AUTH_TOKEN` | _(required)_ | Turso auth token |
-| `CLAUDE_MEMORY_REPLICA_PATH` | `~/.claude/memory.db` | Local embedded replica path |
-| `CLAUDE_MEMORY_SYNC_INTERVAL` | `60` | Turso sync interval (seconds) |
-| `CLAUDE_MEMORY_MODEL_DIR` | `~/.claude/models` | ONNX model directory |
-| `CLAUDE_MEMORY_API_TOKEN` | _(unset = no auth)_ | Bearer token for gRPC/HTTP auth |
-| `CLAUDE_MEMORY_GRPC_PORT` | `8300` | gRPC server port |
-| `CLAUDE_MEMORY_HTTP_PORT` | `8301` | grpc-gateway HTTP port |
-| `CLAUDE_MEMORY_LEGACY_HTTP_PORT` | `8302` | Legacy HTTP API port |
-| `CLAUDE_MEMORY_UI_PORT` | `8080` | Web UI port |
+| `MAGI_REPLICA_PATH` | `~/.magi.db` | Local embedded replica path |
+| `MAGI_SYNC_INTERVAL` | `60` | Turso sync interval (seconds) |
+| `MAGI_MODEL_DIR` | `~/.magi/models` | ONNX model directory |
+| `MAGI_API_TOKEN` | _(unset = no auth)_ | Bearer token for gRPC/HTTP auth |
+| `MAGI_GRPC_PORT` | `8300` | gRPC server port |
+| `MAGI_HTTP_PORT` | `8301` | grpc-gateway HTTP port |
+| `MAGI_LEGACY_HTTP_PORT` | `8302` | Legacy HTTP API port |
+| `MAGI_UI_PORT` | `8080` | Web UI port |
 | `ONNXRUNTIME_LIB` | _(auto-detect)_ | Override ONNX Runtime library path |
 
 ## Importing Existing Data
@@ -184,7 +185,7 @@ See [docs/architecture.md](docs/architecture.md) for detailed data flow.
 ### From memory markdown files
 
 ```bash
-claude-memory-import --dir ~/.claude/memory/
+magi-import --dir ~/.magi/
 ```
 
 ### From Grok/ChatGPT exports

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# claude-memory Roadmap
+# magi Roadmap
 
 ## v0.1 — Current (shipped)
 - MCP stdio server (Claude Code integration)
@@ -26,7 +26,7 @@ Download a repo → binary detects it → syncs project memories → work begins
 
 #### Sync gate
 - Before serving any MCP tool call, check last sync timestamp for current project
-- If stale (> `CLAUDE_MEMORY_SYNC_MAX_AGE`, default 5 min): force sync, wait for completion
+- If stale (> `MAGI_SYNC_MAX_AGE`, default 5 min): force sync, wait for completion
 - Emit a log line: `syncing project memories for j33pguy/IaC...`
 - Then serve the request
 
@@ -53,7 +53,7 @@ Force a sync immediately. Returns when complete.
 {"synced_at": "...", "records_pulled": 12, "project": "..."}
 ```
 
-#### New env var: `CLAUDE_MEMORY_SYNC_MAX_AGE`
+#### New env var: `MAGI_SYNC_MAX_AGE`
 Seconds before a sync is considered stale. Default: 300 (5 min).
 
 ### Config in Claude Code (`~/.claude/CLAUDE.md` injection)
@@ -84,7 +84,7 @@ Returns all `project_context` memories for the current project, formatted as ins
 Claude Code injects these at the top of context automatically.
 
 ### Migration
-- Existing `CLAUDE.md` files can be imported: `claude-memory-import --type project_context --file CLAUDE.md`
+- Existing `CLAUDE.md` files can be imported: `magi-import --type project_context --file CLAUDE.md`
 - After import: delete the file, add to `.gitignore` as a safety net
 - Instructions now invisible to anyone browsing the repo
 
@@ -105,7 +105,7 @@ Each machine has its own local replica. Writes sync up, reads pull down.
 ### Features
 
 #### Machine identity tag
-- Each binary instance has a `CLAUDE_MEMORY_MACHINE_ID` (e.g. `homelab`, `macbook`, `work-laptop`)
+- Each binary instance has a `MAGI_MACHINE_ID` (e.g. `homelab`, `macbook`, `work-laptop`)
 - Stored on every memory: `source_machine: homelab`
 - Useful for: "what did I work on from my MacBook last week?"
 
@@ -122,27 +122,27 @@ Shows which machines have written recently, last seen timestamps.
 ## v0.4 — Ingestion Pipeline
 
 ### The pattern
-Work offline on MacBook → Claude Code session logs captured → ingested into Turso → homelab Claude has full context on next session.
+Work offline on MacBook → Agent session logs captured → ingested into Turso → homelab Claude has full context on next session.
 
 ### Features
 
 #### Session log watcher service
-- Separate binary: `claude-memory-watcher`
-- Watches `~/.claude/projects/*/` for new session log files
+- Separate binary: `magi-watcher`
+- Watches `~/.magi/projects/*/` for new session log files
 - Parses JSONL session logs
 - Extracts: decisions made, code written, errors hit, solutions found
-- Calls `remember` API to store with project tag + `source: claude_session`
+- Calls `remember` API to store with project tag + `source: magi_session`
 
 #### Import sources
-- Claude Code session logs (`~/.claude/projects/**/*.jsonl`)
+- Agent session logs (`~/.magi/projects/**/*.jsonl`)
 - Git commit messages (decisions + context)
 - Markdown notes (manual, existing `cmd/import`)
 - Future: VS Code history, terminal history
 
-#### Watcher config (`~/.claude/memory-watcher.yaml`)
+#### Watcher config (`~/.magi-watcher.yaml`)
 ```yaml
 watch_paths:
-  - ~/.claude/projects
+  - ~/.magi/projects
   - ~/Projects
 import_on_startup: true
 sync_interval: 60
@@ -183,8 +183,8 @@ Summaries are lossy. Can't answer "what exactly did j33p say about X?"
 
 ### Design
 - Each turn stored as a separate embedding with channel + timestamp metadata
-- OpenClaw writes turns to a local queue; background worker batches to claude-memory
-- claude-memory chunks + embeds each turn
+- OpenClaw writes turns to a local queue; background worker batches to magi
+- magi chunks + embeds each turn
 - Recall returns ranked turns by semantic similarity
 
 ### Trade-offs
@@ -196,9 +196,9 @@ More storage, more writes → dramatically better recall precision. Verbatim quo
 
 | Machine | Role | Binary |
 |---|---|---|
-| memory01 (10.5.5.40) | Server — HTTP API + MCP | claude-memory (HTTP mode) |
-| homelab Gilfoyle | MCP client | claude-memory (stdio MCP) |
-| MacBook | MCP client + watcher | claude-memory + claude-memory-watcher |
+| memory01 (10.5.5.40) | Server — HTTP API + MCP | magi (HTTP mode) |
+| homelab Gilfoyle | MCP client | magi (stdio MCP) |
+| MacBook | MCP client + watcher | magi + magi-watcher |
 | Future machines | MCP client + watcher | same |
 
 ## Environment variables (full set)
@@ -207,11 +207,11 @@ More storage, more writes → dramatically better recall precision. Verbatim quo
 |---|---|---|
 | `TURSO_URL` | required | Turso DB URL |
 | `TURSO_AUTH_TOKEN` | required | Turso auth token |
-| `CLAUDE_MEMORY_REPLICA_PATH` | `~/.claude/memory.db` | Local replica path |
-| `CLAUDE_MEMORY_SYNC_INTERVAL` | `60` | Background sync interval (seconds) |
-| `CLAUDE_MEMORY_SYNC_MAX_AGE` | `300` | Stale threshold (seconds) |
-| `CLAUDE_MEMORY_MODEL_DIR` | `~/.claude/models` | ONNX model directory |
-| `CLAUDE_MEMORY_HTTP_PORT` | `8300` | HTTP API port |
-| `CLAUDE_MEMORY_API_TOKEN` | unset = no auth | Bearer token for HTTP API |
-| `CLAUDE_MEMORY_MACHINE_ID` | hostname | Machine identity tag |
-| `CLAUDE_MEMORY_AUTO_PROJECT` | `true` | Auto-detect project from git |
+| `MAGI_REPLICA_PATH` | `~/.magi.db` | Local replica path |
+| `MAGI_SYNC_INTERVAL` | `60` | Background sync interval (seconds) |
+| `MAGI_SYNC_MAX_AGE` | `300` | Stale threshold (seconds) |
+| `MAGI_MODEL_DIR` | `~/.magi/models` | ONNX model directory |
+| `MAGI_HTTP_PORT` | `8300` | HTTP API port |
+| `MAGI_API_TOKEN` | unset = no auth | Bearer token for HTTP API |
+| `MAGI_MACHINE_ID` | hostname | Machine identity tag |
+| `MAGI_AUTO_PROJECT` | `true` | Auto-detect project from git |

--- a/api/conversations.go
+++ b/api/conversations.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/search"
 )
 
 type conversationRequest struct {

--- a/api/memories.go
+++ b/api/memories.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/tools"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/tools"
 )
 
 func (s *Server) handleListMemories(w http.ResponseWriter, r *http.Request) {

--- a/api/recall.go
+++ b/api/recall.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/search"
-	"github.com/j33pguy/claude-memory/tools"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/search"
+	"github.com/j33pguy/magi/tools"
 )
 
 type recallRequest struct {

--- a/api/remember.go
+++ b/api/remember.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 type rememberRequest struct {

--- a/api/search.go
+++ b/api/search.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/search"
 )
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {

--- a/api/server.go
+++ b/api/server.go
@@ -1,4 +1,4 @@
-// Package api provides an HTTP API layer for claude-memory.
+// Package api provides an HTTP API layer for magi.
 package api
 
 import (
@@ -10,11 +10,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
-// Server is the HTTP API server for claude-memory.
+// Server is the HTTP API server for magi.
 type Server struct {
 	httpServer *http.Server
 	db         *db.Client
@@ -29,10 +29,10 @@ func NewServer(dbClient *db.Client, embedder embeddings.Provider, logger *slog.L
 		db:       dbClient,
 		embedder: embedder,
 		logger:   logger,
-		token:    os.Getenv("CLAUDE_MEMORY_API_TOKEN"),
+		token:    os.Getenv("MAGI_API_TOKEN"),
 	}
 
-	port := os.Getenv("CLAUDE_MEMORY_LEGACY_HTTP_PORT")
+	port := os.Getenv("MAGI_LEGACY_HTTP_PORT")
 	if port == "" {
 		port = "8302"
 	}
@@ -61,7 +61,7 @@ func NewServer(dbClient *db.Client, embedder embeddings.Provider, logger *slog.L
 // Start begins listening for HTTP requests. Blocks until the server stops.
 func (s *Server) Start() error {
 	if s.token == "" {
-		s.logger.Warn("CLAUDE_MEMORY_API_TOKEN not set, running without auth (dev mode)")
+		s.logger.Warn("MAGI_API_TOKEN not set, running without auth (dev mode)")
 	}
 	s.logger.Info("Starting HTTP API server", "addr", s.httpServer.Addr)
 	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/classify/classify.go
+++ b/classify/classify.go
@@ -26,7 +26,7 @@ var rules = []rule{
 	{regexp.MustCompile(`(?i)azure|microsoft 365|m365|\bteams\b|entra`), "work", "azure"},
 
 	// project (before homelab — more specific patterns like vault-unsealer must match before generic vault)
-	{regexp.MustCompile(`(?i)claude.?memory|memory server|mcp server`), "project", "claude-memory"},
+	{regexp.MustCompile(`(?i)claude.?memory|memory server|mcp server`), "project", "magi"},
 	{regexp.MustCompile(`(?i)distify|behavioral trust|trust verification`), "project", "distify"},
 	{regexp.MustCompile(`(?i)labctl|lab.?ctl`), "project", "labctl"},
 	{regexp.MustCompile(`(?i)vault.?unsealer|auto.?unseal`), "project", "vault-unsealer"},

--- a/classify/classify_test.go
+++ b/classify/classify_test.go
@@ -46,10 +46,10 @@ func TestInfer(t *testing.T) {
 			subArea: "dns",
 		},
 		{
-			name:    "claude-memory project",
-			content: "Refactored claude-memory MCP server to use gRPC transport",
+			name:    "magi project",
+			content: "Refactored magi MCP server to use gRPC transport",
 			area:    "project",
-			subArea: "claude-memory",
+			subArea: "magi",
 		},
 		{
 			name:    "vault unsealer",

--- a/cmd/analyze-patterns/main.go
+++ b/cmd/analyze-patterns/main.go
@@ -1,5 +1,5 @@
 // Package main provides a CLI tool for analyzing behavioral patterns
-// from the claude-memory database.
+// from the magi database.
 package main
 
 import (
@@ -10,9 +10,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/patterns"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/patterns"
 )
 
 func main() {

--- a/cmd/import/main.go
+++ b/cmd/import/main.go
@@ -1,5 +1,5 @@
 // Package main provides a CLI tool for importing existing markdown memory files
-// into the claude-memory database.
+// into the magi database.
 package main
 
 import (
@@ -9,10 +9,10 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/j33pguy/claude-memory/chunking"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/migrate"
+	"github.com/j33pguy/magi/chunking"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/migrate"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	flag.Parse()
 
 	if *dir == "" {
-		fmt.Fprintln(os.Stderr, "Usage: claude-memory-import --dir <path>")
+		fmt.Fprintln(os.Stderr, "Usage: magi-import --dir <path>")
 		os.Exit(1)
 	}
 

--- a/contradiction/detect.go
+++ b/contradiction/detect.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // Candidate is a potentially contradicting memory pair.

--- a/db/client.go
+++ b/db/client.go
@@ -1,4 +1,4 @@
-// Package db provides database access for the claude-memory server using Turso
+// Package db provides database access for the magi server using Turso
 // with embedded replicas for fast local reads and cloud sync.
 package db
 
@@ -33,14 +33,14 @@ type TursoConfig struct {
 
 // tursoConfigFromEnv reads Turso configuration from environment variables.
 func tursoConfigFromEnv() *TursoConfig {
-	replicaPath := os.Getenv("CLAUDE_MEMORY_REPLICA_PATH")
+	replicaPath := os.Getenv("MAGI_REPLICA_PATH")
 	if replicaPath == "" {
 		home, _ := os.UserHomeDir()
 		replicaPath = filepath.Join(home, ".claude", "memory.db")
 	}
 
 	syncInterval := 60 * time.Second
-	if v := os.Getenv("CLAUDE_MEMORY_SYNC_INTERVAL"); v != "" {
+	if v := os.Getenv("MAGI_SYNC_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v + "s"); err == nil {
 			syncInterval = d
 		}

--- a/db/factory.go
+++ b/db/factory.go
@@ -26,13 +26,13 @@ type Config struct {
 func ConfigFromEnv() *Config {
 	home, _ := os.UserHomeDir()
 
-	replicaPath := os.Getenv("CLAUDE_MEMORY_REPLICA_PATH")
+	replicaPath := os.Getenv("MAGI_REPLICA_PATH")
 	if replicaPath == "" {
 		replicaPath = filepath.Join(home, ".claude", "memory.db")
 	}
 
 	syncInterval := 60 * time.Second
-	if v := os.Getenv("CLAUDE_MEMORY_SYNC_INTERVAL"); v != "" {
+	if v := os.Getenv("MAGI_SYNC_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v + "s"); err == nil {
 			syncInterval = d
 		}

--- a/db/memory.go
+++ b/db/memory.go
@@ -28,7 +28,7 @@ type Memory struct {
 	Speaker string `json:"speaker,omitempty"`
 	// Area is the top-level domain: work, home, family, homelab, project, meta
 	Area string `json:"area,omitempty"`
-	// SubArea is a free-form sub-domain (power-platform, proxmox, claude-memory, etc.)
+	// SubArea is a free-form sub-domain (power-platform, proxmox, magi, etc.)
 	SubArea   string   `json:"subArea,omitempty"`
 	CreatedAt  string  `json:"createdAt"`
 	UpdatedAt  string  `json:"updatedAt"`
@@ -57,7 +57,7 @@ type MemoryFilter struct {
 	Speaker string
 	// Area filters by top-level domain (work, home, family, homelab, project, meta).
 	Area string
-	// SubArea filters by sub-domain (power-platform, proxmox, claude-memory, etc.).
+	// SubArea filters by sub-domain (power-platform, proxmox, magi, etc.).
 	SubArea string
 	// AfterTime filters to memories created after this time.
 	AfterTime *time.Time

--- a/db/schema.go
+++ b/db/schema.go
@@ -216,7 +216,7 @@ CREATE INDEX IF NOT EXISTS idx_memories_type_created ON memories(type, created_a
 // migrationV5 adds structured taxonomy fields for categorized recall.
 // speaker: who said/wrote this (j33p, gilfoyle, agent, system)
 // area: top-level domain (work, home, family, homelab, project, meta)
-// sub_area: sub-domain, free-form (power-platform, proxmox, claude-memory, etc.)
+// sub_area: sub-domain, free-form (power-platform, proxmox, magi, etc.)
 const migrationV5 = `
 ALTER TABLE memories ADD COLUMN speaker TEXT NOT NULL DEFAULT '';
 ALTER TABLE memories ADD COLUMN area TEXT NOT NULL DEFAULT '';

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-claude-memory is a single Go binary that runs four server interfaces concurrently, all backed by the same database and embedding engine.
+magi is a single Go binary that runs four server interfaces concurrently, all backed by the same database and embedding engine.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                          claude-memory (Go binary)                       │
+│                          magi (Go binary)                       │
 │                                                                          │
 │  ┌─────────┐  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  │
 │  │  MCP    │  │   gRPC       │  │ grpc-gateway │  │  Legacy HTTP    │  │
@@ -43,7 +43,7 @@ claude-memory is a single Go binary that runs four server interfaces concurrentl
 │  │                                                                    │  │
 │  │  ┌──────────────────────┐      ┌────────────────────────────┐     │  │
 │  │  │  Local SQLite Replica │◀───▶│     Turso Cloud Database   │     │  │
-│  │  │  ~/.claude/memory.db  │ sync │  libsql + vector search   │     │  │
+│  │  │  ~/.magi.db  │ sync │  libsql + vector search   │     │  │
 │  │  │  (fast offline reads) │      │  (distributed, durable)   │     │  │
 │  │  └──────────────────────┘      └────────────────────────────┘     │  │
 │  └───────────────────────────────────────────────────────────────────┘  │
@@ -99,7 +99,7 @@ Local embedded replica ◀──── periodic sync (default 60s) ────�
 
 - Reads: always from local replica (fast, offline-capable)
 - Writes: to local replica, synced to cloud
-- Multiple claude-memory instances stay in sync via Turso
+- Multiple magi instances stay in sync via Turso
 ```
 
 ## Database Schema
@@ -129,7 +129,7 @@ type TEXT DEFAULT 'memory'     -- decision, lesson, incident, etc.
 visibility TEXT DEFAULT 'internal'
 speaker TEXT                   -- j33p, gilfoyle, agent, system
 area TEXT                      -- work, home, family, homelab, project, meta
-sub_area TEXT                  -- power-platform, proxmox, claude-memory, etc.
+sub_area TEXT                  -- power-platform, proxmox, magi, etc.
 parent_id TEXT                 -- soft-grouping via dedup
 created_at TEXT
 updated_at TEXT
@@ -174,7 +174,7 @@ Content → BERT WordPiece tokenizer → all-MiniLM-L6-v2 (ONNX) → 384-dim flo
 |------|-----------|
 | work | power-platform, fabric, power-bi, sharepoint, td-synnex, azure |
 | homelab | iac, proxmox, dns, networking, vault, authentik, monitoring, lancache |
-| project | claude-memory, distify, labctl, vault-unsealer |
+| project | magi, distify, labctl, vault-unsealer |
 | home | lego, streaming, gaming |
 | family | kids, spouse |
 | meta | _(reserved)_ |
@@ -209,7 +209,7 @@ Patterns are stored as `type=preference` memories with `pattern` tag, deduplicat
 ## Project Structure
 
 ```
-claude-memory/
+magi/
 ├── main.go                  # Entry point, CLI flags, server startup
 ├── server/                  # MCP server setup, tool/resource registration
 ├── db/                      # Turso client, schema migrations, CRUD, tags, links

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,14 +29,14 @@ sudo ldconfig
 ## Building
 
 ```bash
-git clone https://github.com/j33pguy/claude-memory
-cd claude-memory
+git clone https://github.com/j33pguy/magi
+cd magi
 CGO_ENABLED=1 make build
 ```
 
 This produces two binaries in `bin/`:
-- `claude-memory` — main server
-- `claude-memory-import` — memory file importer
+- `magi` — main server
+- `magi-import` — memory file importer
 
 Install system-wide:
 ```bash
@@ -45,38 +45,38 @@ sudo make install   # copies to /usr/local/bin/
 
 ## Systemd Service
 
-Create `/etc/systemd/system/claude-memory.service`:
+Create `/etc/systemd/system/magi.service`:
 
 ```ini
 [Unit]
-Description=claude-memory AI memory server
+Description=magi AI memory server
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-User=claude-memory
-Group=claude-memory
-ExecStart=/opt/claude-memory/bin/claude-memory --http-only
+User=magi
+Group=magi
+ExecStart=/opt/magi/bin/magi --http-only
 Restart=on-failure
 RestartSec=5
 
 # Environment
-Environment=TURSO_URL=libsql://claude-memory-<you>.turso.io
+Environment=TURSO_URL=libsql://magi-<you>.turso.io
 Environment=TURSO_AUTH_TOKEN=<token>
-Environment=CLAUDE_MEMORY_API_TOKEN=<bearer-token>
-Environment=CLAUDE_MEMORY_REPLICA_PATH=/var/lib/claude-memory/memory.db
-Environment=CLAUDE_MEMORY_MODEL_DIR=/opt/claude-memory/models
-Environment=CLAUDE_MEMORY_GRPC_PORT=8300
-Environment=CLAUDE_MEMORY_HTTP_PORT=8301
-Environment=CLAUDE_MEMORY_LEGACY_HTTP_PORT=8302
-Environment=CLAUDE_MEMORY_UI_PORT=8080
+Environment=MAGI_API_TOKEN=<bearer-token>
+Environment=MAGI_REPLICA_PATH=/var/lib/magi/memory.db
+Environment=MAGI_MODEL_DIR=/opt/magi/models
+Environment=MAGI_GRPC_PORT=8300
+Environment=MAGI_HTTP_PORT=8301
+Environment=MAGI_LEGACY_HTTP_PORT=8302
+Environment=MAGI_UI_PORT=8080
 
 # Hardening
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/var/lib/claude-memory
+ReadWritePaths=/var/lib/magi
 PrivateTmp=true
 
 [Install]
@@ -87,14 +87,14 @@ Set up the service:
 
 ```bash
 # Create service user
-sudo useradd -r -s /sbin/nologin claude-memory
+sudo useradd -r -s /sbin/nologin magi
 
 # Create data directory
-sudo mkdir -p /var/lib/claude-memory /opt/claude-memory/bin /opt/claude-memory/models
-sudo chown claude-memory:claude-memory /var/lib/claude-memory
+sudo mkdir -p /var/lib/magi /opt/magi/bin /opt/magi/models
+sudo chown magi:magi /var/lib/magi
 
 # Install binary
-sudo cp bin/claude-memory /opt/claude-memory/bin/
+sudo cp bin/magi /opt/magi/bin/
 
 # Download ONNX model (first run)
 # The model is auto-downloaded to MODEL_DIR on first startup,
@@ -102,12 +102,12 @@ sudo cp bin/claude-memory /opt/claude-memory/bin/
 
 # Enable and start
 sudo systemctl daemon-reload
-sudo systemctl enable claude-memory
-sudo systemctl start claude-memory
+sudo systemctl enable magi
+sudo systemctl start magi
 
 # Check status
-sudo systemctl status claude-memory
-journalctl -u claude-memory -f
+sudo systemctl status magi
+journalctl -u magi -f
 ```
 
 **Note:** The `--http-only` flag runs gRPC, grpc-gateway, legacy HTTP, and web UI servers without the stdio MCP server. MCP mode is for direct Claude Code integration (where the binary is launched by Claude Code as a subprocess).
@@ -117,12 +117,12 @@ journalctl -u claude-memory -f
 Example Traefik dynamic config to expose the web UI and API behind authentication:
 
 ```yaml
-# traefik/dynamic/claude-memory.yml
+# traefik/dynamic/magi.yml
 http:
   routers:
-    claude-memory-ui:
+    magi-ui:
       rule: "Host(`memory.example.com`)"
-      service: claude-memory-ui
+      service: magi-ui
       entryPoints:
         - websecure
       tls:
@@ -130,9 +130,9 @@ http:
       middlewares:
         - authentik@docker   # or your auth middleware
 
-    claude-memory-api:
+    magi-api:
       rule: "Host(`memory-api.example.com`)"
-      service: claude-memory-api
+      service: magi-api
       entryPoints:
         - websecure
       tls:
@@ -140,12 +140,12 @@ http:
       # API uses Bearer token auth, no middleware needed
 
   services:
-    claude-memory-ui:
+    magi-ui:
       loadBalancer:
         servers:
           - url: "http://localhost:8080"
 
-    claude-memory-api:
+    magi-api:
       loadBalancer:
         servers:
           - url: "http://localhost:8302"
@@ -155,17 +155,17 @@ http:
 
 | Port | Protocol | Interface | Purpose |
 |------|----------|-----------|---------|
-| 8300 | gRPC (h2) | `CLAUDE_MEMORY_GRPC_PORT` | Native gRPC clients |
-| 8301 | HTTP/JSON | `CLAUDE_MEMORY_HTTP_PORT` | grpc-gateway reverse proxy |
-| 8302 | HTTP/JSON | `CLAUDE_MEMORY_LEGACY_HTTP_PORT` | Legacy REST API |
-| 8080 | HTTP | `CLAUDE_MEMORY_UI_PORT` | Web UI |
+| 8300 | gRPC (h2) | `MAGI_GRPC_PORT` | Native gRPC clients |
+| 8301 | HTTP/JSON | `MAGI_HTTP_PORT` | grpc-gateway reverse proxy |
+| 8302 | HTTP/JSON | `MAGI_LEGACY_HTTP_PORT` | Legacy REST API |
+| 8080 | HTTP | `MAGI_UI_PORT` | Web UI |
 
 ## CI/CD
 
 The project uses GitHub Actions with a self-hosted runner. On push to `main`:
 
 1. **Build & Test** — `go build`, `go test`, `go vet`
-2. **Deploy** — builds production binary, installs to `/opt/claude-memory/bin/`, restarts systemd service, verifies health
+2. **Deploy** — builds production binary, installs to `/opt/magi/bin/`, restarts systemd service, verifies health
 
 The runner runs directly on the target server, so deployment is a local copy + restart (no SSH/SCP).
 
@@ -174,24 +174,24 @@ The runner runs directly on the target server, so deployment is a local copy + r
 1. Create a free Turso account at [turso.tech](https://turso.tech)
 2. Create a database:
    ```bash
-   turso db create claude-memory
+   turso db create magi
    ```
 3. Get the URL and token:
    ```bash
-   turso db show claude-memory --url
-   turso db tokens create claude-memory
+   turso db show magi --url
+   turso db tokens create magi
    ```
 4. Set environment variables:
    ```bash
-   export TURSO_URL=libsql://claude-memory-<you>.turso.io
+   export TURSO_URL=libsql://magi-<you>.turso.io
    export TURSO_AUTH_TOKEN=<token>
    ```
 
-Schema migrations run automatically on startup. The embedded replica syncs to Turso cloud every 60 seconds (configurable via `CLAUDE_MEMORY_SYNC_INTERVAL`).
+Schema migrations run automatically on startup. The embedded replica syncs to Turso cloud every 60 seconds (configurable via `MAGI_SYNC_INTERVAL`).
 
 ## Model Setup
 
-The ONNX model (all-MiniLM-L6-v2) is auto-downloaded on first run to `CLAUDE_MEMORY_MODEL_DIR` (default `~/.claude/models/`). For air-gapped deployments, download the model files manually:
+The ONNX model (all-MiniLM-L6-v2) is auto-downloaded on first run to `MAGI_MODEL_DIR` (default `~/.claude/models/`). For air-gapped deployments, download the model files manually:
 
 - `model.onnx` — the ONNX model
 - `tokenizer.json` or `vocab.txt` — BERT WordPiece vocabulary

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,16 +1,16 @@
 # HTTP API Reference
 
-claude-memory exposes two HTTP APIs:
+magi exposes two HTTP APIs:
 
 - **grpc-gateway** on `:8301` — auto-generated JSON proxy from the gRPC service definition
 - **Legacy HTTP API** on `:8302` — hand-written REST handlers (will be removed once grpc-gateway is proven)
 
-Both use Bearer token auth via the `Authorization` header. Set `CLAUDE_MEMORY_API_TOKEN` to enable authentication. If unset, all requests are allowed (dev mode).
+Both use Bearer token auth via the `Authorization` header. Set `MAGI_API_TOKEN` to enable authentication. If unset, all requests are allowed (dev mode).
 
 ## Authentication
 
 ```bash
-curl -H "Authorization: Bearer $CLAUDE_MEMORY_API_TOKEN" http://localhost:8302/memories
+curl -H "Authorization: Bearer $MAGI_API_TOKEN" http://localhost:8302/memories
 ```
 
 ## Legacy HTTP API (`:8302`)
@@ -202,7 +202,7 @@ curl -X POST http://localhost:8302/conversations \
   -H "Content-Type: application/json" \
   -d '{
     "channel": "discord",
-    "summary": "Discussed claude-memory deployment strategy and cross-channel sync",
+    "summary": "Discussed magi deployment strategy and cross-channel sync",
     "session_key": "abc123",
     "turn_count": 12,
     "topics": ["deployment", "cross-channel sync"],

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-claude-memory exposes 17 MCP tools via stdio for use with Claude Code. All tools accept JSON parameters and return JSON responses.
+magi exposes 17 MCP tools via stdio for use with Claude Code. All tools accept JSON parameters and return JSON responses.
 
 ## Core Memory Operations
 
@@ -11,13 +11,13 @@ Store a memory with automatic semantic embedding, deduplication, and contradicti
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | yes | The content to remember |
-| `project` | string | yes | Project namespace (e.g. `iac`, `claude-memory`, `global`) |
+| `project` | string | yes | Project namespace (e.g. `iac`, `magi`, `global`) |
 | `type` | string | no | Memory type: `memory`, `incident`, `lesson`, `decision`, `project_context`, `conversation`, `audit`, `runbook`, `preference`, `context`, `security` |
 | `summary` | string | no | Brief one-line summary |
 | `tags` | string[] | no | Tags for categorization |
 | `speaker` | string | no | Who said this: `j33p`, `gilfoyle`, `agent`, `system`. Default: `gilfoyle` |
 | `area` | string | no | Top-level domain: `work`, `home`, `family`, `homelab`, `project`, `meta` |
-| `sub_area` | string | no | Sub-domain (e.g. `power-platform`, `proxmox`, `claude-memory`) |
+| `sub_area` | string | no | Sub-domain (e.g. `power-platform`, `proxmox`, `magi`) |
 | `dedup_threshold` | number | no | Similarity threshold for dedup (0.0–1.0, default 0.95) |
 
 **Behavior:**

--- a/embeddings/onnx.go
+++ b/embeddings/onnx.go
@@ -43,7 +43,7 @@ type OnnxProvider struct {
 // NewOnnxProvider creates a new ONNX embedding provider. Downloads the model
 // and vocab on first use if not already cached.
 func NewOnnxProvider(logger *slog.Logger) (*OnnxProvider, error) {
-	modelDir := os.Getenv("CLAUDE_MEMORY_MODEL_DIR")
+	modelDir := os.Getenv("MAGI_MODEL_DIR")
 	if modelDir == "" {
 		home, _ := os.UserHomeDir()
 		modelDir = filepath.Join(home, ".claude", "models")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/j33pguy/claude-memory
+module github.com/j33pguy/magi
 
 go 1.25.5
 

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -10,11 +10,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	pb "github.com/j33pguy/claude-memory/proto/memory/v1"
-	"github.com/j33pguy/claude-memory/search"
-	"github.com/j33pguy/claude-memory/tools"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	pb "github.com/j33pguy/magi/proto/memory/v1"
+	"github.com/j33pguy/magi/search"
+	"github.com/j33pguy/magi/tools"
 )
 
 // Server implements the MemoryService gRPC service.

--- a/grpc/server_test.go
+++ b/grpc/server_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
-	memgrpc "github.com/j33pguy/claude-memory/grpc"
-	pb "github.com/j33pguy/claude-memory/proto/memory/v1"
+	memgrpc "github.com/j33pguy/magi/grpc"
+	pb "github.com/j33pguy/magi/proto/memory/v1"
 )
 
 // recoveryInterceptor catches panics from nil deps in test and returns Internal.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for the claude-memory MCP server.
+// Package main is the entry point for the magi MCP server.
 // It provides a RAG-based memory system for Claude Code using Turso
 // (distributed libSQL with vector search) and local ONNX embeddings.
 package main
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/j33pguy/claude-memory/server"
+	"github.com/j33pguy/magi/server"
 )
 
 func main() {

--- a/migrate/markdown.go
+++ b/migrate/markdown.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/j33pguy/claude-memory/chunking"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/chunking"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // MarkdownImporter imports markdown memory files into the database.

--- a/patterns/analyzer.go
+++ b/patterns/analyzer.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // PatternType categorizes what kind of behavioral pattern was detected.

--- a/patterns/analyzer_test.go
+++ b/patterns/analyzer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 func TestAnalyze_EmptyInput(t *testing.T) {

--- a/patterns/store.go
+++ b/patterns/store.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // StorePatterns saves detected patterns as memories in the DB.

--- a/proto/memory/v1/memory.pb.go
+++ b/proto/memory/v1/memory.pb.go
@@ -43,7 +43,7 @@ type Memory struct {
 	Speaker string `protobuf:"bytes,15,opt,name=speaker,proto3" json:"speaker,omitempty"`
 	// Taxonomy: top-level domain (work, home, family, homelab, project, meta)
 	Area string `protobuf:"bytes,16,opt,name=area,proto3" json:"area,omitempty"`
-	// Taxonomy: sub-domain, free-form (power-platform, proxmox, claude-memory, etc.)
+	// Taxonomy: sub-domain, free-form (power-platform, proxmox, magi, etc.)
 	SubArea       string `protobuf:"bytes,17,opt,name=sub_area,json=subArea,proto3" json:"sub_area,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1479,7 +1479,7 @@ const file_memory_v1_memory_proto_rawDesc = "" +
 	"\x04List\x12\x16.memory.v1.ListRequest\x1a\x17.memory.v1.ListResponse\"\x11\x82\xd3\xe4\x93\x02\v\x12\t/memories\x12N\n" +
 	"\x06Health\x12\x18.memory.v1.HealthRequest\x1a\x19.memory.v1.HealthResponse\"\x0f\x82\xd3\xe4\x93\x02\t\x12\a/health\x12|\n" +
 	"\x12CreateConversation\x12$.memory.v1.CreateConversationRequest\x1a%.memory.v1.CreateConversationResponse\"\x19\x82\xd3\xe4\x93\x02\x13:\x01*\"\x0e/conversations\x12\x86\x01\n" +
-	"\x13SearchConversations\x12%.memory.v1.SearchConversationsRequest\x1a&.memory.v1.SearchConversationsResponse\" \x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/conversations/searchB;Z9github.com/j33pguy/claude-memory/proto/memory/v1;memorypbb\x06proto3"
+	"\x13SearchConversations\x12%.memory.v1.SearchConversationsRequest\x1a&.memory.v1.SearchConversationsResponse\" \x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/conversations/searchB;Z9github.com/j33pguy/magi/proto/memory/v1;memorypbb\x06proto3"
 
 var (
 	file_memory_v1_memory_proto_rawDescOnce sync.Once

--- a/proto/memory/v1/memory.proto
+++ b/proto/memory/v1/memory.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package memory.v1;
-option go_package = "github.com/j33pguy/claude-memory/proto/memory/v1;memorypb";
+option go_package = "github.com/j33pguy/magi/proto/memory/v1;memorypb";
 
 import "google/api/annotations.proto";
 
@@ -77,7 +77,7 @@ message Memory {
   string speaker = 15;
   // Taxonomy: top-level domain (work, home, family, homelab, project, meta)
   string area = 16;
-  // Taxonomy: sub-domain, free-form (power-platform, proxmox, claude-memory, etc.)
+  // Taxonomy: sub-domain, free-form (power-platform, proxmox, magi, etc.)
   string sub_area = 17;
 }
 

--- a/resources/context.go
+++ b/resources/context.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // Context provides recent and important memories for session auto-injection.

--- a/resources/conversations.go
+++ b/resources/conversations.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // RecentConversations provides recent conversation summaries across all channels.

--- a/resources/decisions.go
+++ b/resources/decisions.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // Decisions provides architecture decision memories for a project.

--- a/resources/patterns.go
+++ b/resources/patterns.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // Patterns provides all detected behavioral patterns.

--- a/resources/preferences.go
+++ b/resources/preferences.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // Preferences provides all user preference memories.

--- a/resources/recent.go
+++ b/resources/recent.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // Recent provides the 10 most recent memories for a project.

--- a/search/adaptive.go
+++ b/search/adaptive.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/rewrite"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/rewrite"
 )
 
 // Response wraps search results with adaptive retrieval metadata.

--- a/search/recency.go
+++ b/search/recency.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // ApplyRecencyWeighting multiplies each result's Score by an exponential decay

--- a/search/recency_test.go
+++ b/search/recency_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 func TestApplyRecencyWeighting_Disabled(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -15,17 +15,17 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/j33pguy/claude-memory/api"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	memgrpc "github.com/j33pguy/claude-memory/grpc"
-	pb "github.com/j33pguy/claude-memory/proto/memory/v1"
-	"github.com/j33pguy/claude-memory/resources"
-	"github.com/j33pguy/claude-memory/tools"
-	"github.com/j33pguy/claude-memory/web"
+	"github.com/j33pguy/magi/api"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	memgrpc "github.com/j33pguy/magi/grpc"
+	pb "github.com/j33pguy/magi/proto/memory/v1"
+	"github.com/j33pguy/magi/resources"
+	"github.com/j33pguy/magi/tools"
+	"github.com/j33pguy/magi/web"
 )
 
-// Server is the claude-memory MCP server.
+// Server is the magi MCP server.
 type Server struct {
 	mcp        *mcpserver.MCPServer
 	httpAPI    *api.Server
@@ -37,7 +37,7 @@ type Server struct {
 	logger     *slog.Logger
 }
 
-// New creates and configures a new claude-memory MCP server.
+// New creates and configures a new magi MCP server.
 func New(logger *slog.Logger) (*Server, error) {
 	// Initialize database
 	dbCfg := db.ConfigFromEnv()
@@ -66,7 +66,7 @@ func New(logger *slog.Logger) (*Server, error) {
 	}
 
 	s.mcp = mcpserver.NewMCPServer(
-		"claude-memory",
+		"magi",
 		"0.1.0",
 		mcpserver.WithToolCapabilities(false),
 		mcpserver.WithResourceCapabilities(false, false),
@@ -77,7 +77,7 @@ func New(logger *slog.Logger) (*Server, error) {
 	s.registerResources()
 
 	// gRPC server with auth interceptor
-	token := os.Getenv("CLAUDE_MEMORY_API_TOKEN")
+	token := os.Getenv("MAGI_API_TOKEN")
 	s.grpcServer = grpc.NewServer(
 		grpc.UnaryInterceptor(memgrpc.AuthInterceptor(token)),
 	)
@@ -163,7 +163,7 @@ pats := &resources.Patterns{DB: s.dbClient}
 
 // ServeGRPC starts the gRPC server. Blocks until the server stops.
 func (s *Server) ServeGRPC() error {
-	port := os.Getenv("CLAUDE_MEMORY_GRPC_PORT")
+	port := os.Getenv("MAGI_GRPC_PORT")
 	if port == "" {
 		port = "8300"
 	}
@@ -183,11 +183,11 @@ func (s *Server) ServeGRPC() error {
 // ServeGateway starts the grpc-gateway HTTP/JSON reverse proxy.
 // It connects to the gRPC server and proxies JSON requests.
 func (s *Server) ServeGateway() error {
-	port := os.Getenv("CLAUDE_MEMORY_HTTP_PORT")
+	port := os.Getenv("MAGI_HTTP_PORT")
 	if port == "" {
 		port = "8301"
 	}
-	grpcPort := os.Getenv("CLAUDE_MEMORY_GRPC_PORT")
+	grpcPort := os.Getenv("MAGI_GRPC_PORT")
 	if grpcPort == "" {
 		grpcPort = "8300"
 	}
@@ -216,7 +216,7 @@ func (s *Server) ServeGateway() error {
 
 // ServeWeb starts the web UI server. Blocks until the server stops.
 func (s *Server) ServeWeb() error {
-	port := os.Getenv("CLAUDE_MEMORY_UI_PORT")
+	port := os.Getenv("MAGI_UI_PORT")
 	if port == "" {
 		port = "8080"
 	}
@@ -266,7 +266,7 @@ func (s *Server) ShutdownGRPC(ctx context.Context) error {
 
 // Run starts the MCP server on stdio.
 func (s *Server) Run() error {
-	s.logger.Info("Starting claude-memory MCP server")
+	s.logger.Info("Starting magi MCP server")
 	return mcpserver.ServeStdio(s.mcp)
 }
 

--- a/tools/check_contradictions.go
+++ b/tools/check_contradictions.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/contradiction"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/contradiction"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // CheckContradictions exposes contradiction detection as a standalone MCP tool.

--- a/tools/forget.go
+++ b/tools/forget.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // Forget soft-deletes (archives) or permanently deletes a memory.

--- a/tools/index_session.go
+++ b/tools/index_session.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/classify"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/classify"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // IndexSession bulk-indexes a completed conversation session.

--- a/tools/index_turn.go
+++ b/tools/index_turn.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/classify"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/classify"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // IndexTurn stores a single conversation turn as a memory.

--- a/tools/ingest.go
+++ b/tools/ingest.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/classify"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/ingest"
+	"github.com/j33pguy/magi/classify"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/ingest"
 )
 
 // IngestConversation imports a conversation export into memory.

--- a/tools/links.go
+++ b/tools/links.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // LinkMemories creates a directed link between two memories.

--- a/tools/list.go
+++ b/tools/list.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -34,7 +34,7 @@ func (l *List) Tool() mcp.Tool {
 			mcp.Description("Filter by area: work, home, family, homelab, project, meta"),
 			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
 		),
-		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, claude-memory)")),
+		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, magi)")),
 		mcp.WithString("after", mcp.Description("Only memories created after this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
 		mcp.WithString("before", mcp.Description("Only memories created before this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
 	)

--- a/tools/recall.go
+++ b/tools/recall.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/search"
 )
 
 // Recall performs hybrid search (BM25 + vector + RRF) over stored memories.
@@ -40,7 +40,7 @@ func (r *Recall) Tool() mcp.Tool {
 			mcp.Description("Filter by area: work, home, family, homelab, project, meta"),
 			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
 		),
-		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, claude-memory)")),
+		mcp.WithString("sub_area", mcp.Description("Filter by sub-area (e.g. power-platform, proxmox, magi)")),
 		mcp.WithString("after", mcp.Description("Only memories created after this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
 		mcp.WithString("before", mcp.Description("Only memories created before this time. Relative (7d, 2w, 1m, 1y) or absolute (2006-01-02, RFC3339).")),
 	)

--- a/tools/recall_conversations.go
+++ b/tools/recall_conversations.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/search"
 )
 
 // RecallConversations searches conversation memories using hybrid retrieval.

--- a/tools/recall_incidents.go
+++ b/tools/recall_incidents.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/search"
 )
 
 // RecallIncidents searches only incident-type memories (things that broke + how they were fixed).

--- a/tools/recall_lessons.go
+++ b/tools/recall_lessons.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/search"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/search"
 )
 
 // RecallLessons searches only lesson-type memories (hard-won knowledge, gotchas).

--- a/tools/recent_conversations.go
+++ b/tools/recent_conversations.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
+	"github.com/j33pguy/magi/db"
 )
 
 // RecentConversations lists recent conversation summaries with optional filtering.

--- a/tools/remember.go
+++ b/tools/remember.go
@@ -1,4 +1,4 @@
-// Package tools implements MCP tool handlers for the claude-memory server.
+// Package tools implements MCP tool handlers for the magi server.
 package tools
 
 import (
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/classify"
-	"github.com/j33pguy/claude-memory/contradiction"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/classify"
+	"github.com/j33pguy/magi/contradiction"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // Remember stores a new memory with auto-generated embedding.
@@ -43,7 +43,7 @@ func (r *Remember) Tool() mcp.Tool {
 			mcp.Enum("work", "home", "family", "homelab", "project", "meta"),
 		),
 		mcp.WithString("sub_area",
-			mcp.Description("Sub-domain within area (e.g. unifi-vlans, unifi-switches, pihole-ha, vault-cluster). For type=state: use a specific component name so current state is queryable by sub_area. Examples — work: power-platform, fabric, power-bi, sharepoint, teams, azure, td-synnex; homelab: proxmox, networking, security, dns, monitoring, storage, iac, vault, traefik, authentik, lancache; project: claude-memory, distify, labctl, vault-unsealer, iac; home: lego, gaming, streaming, media; family: kids, spouse, schedule"),
+			mcp.Description("Sub-domain within area (e.g. unifi-vlans, unifi-switches, pihole-ha, vault-cluster). For type=state: use a specific component name so current state is queryable by sub_area. Examples — work: power-platform, fabric, power-bi, sharepoint, teams, azure, td-synnex; homelab: proxmox, networking, security, dns, monitoring, storage, iac, vault, traefik, authentik, lancache; project: magi, distify, labctl, vault-unsealer, iac; home: lego, gaming, streaming, media; family: kids, spouse, schedule"),
 		),
 	)
 }

--- a/tools/store_conversation.go
+++ b/tools/store_conversation.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // StoreConversation stores a conversation summary with auto-embedding and tagging.

--- a/tools/update.go
+++ b/tools/update.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
 )
 
 // Update modifies an existing memory's content or metadata, re-embedding if content changed.

--- a/web/server.go
+++ b/web/server.go
@@ -1,4 +1,4 @@
-// Package web provides an embedded web GUI for browsing claude-memory.
+// Package web provides an embedded web GUI for browsing magi.
 package web
 
 import (
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/j33pguy/claude-memory/classify"
-	"github.com/j33pguy/claude-memory/db"
-	"github.com/j33pguy/claude-memory/embeddings"
-	"github.com/j33pguy/claude-memory/patterns"
-"github.com/j33pguy/claude-memory/ingest"
+	"github.com/j33pguy/magi/classify"
+	"github.com/j33pguy/magi/db"
+	"github.com/j33pguy/magi/embeddings"
+	"github.com/j33pguy/magi/patterns"
+"github.com/j33pguy/magi/ingest"
 )
 
 const pageSize = 30

--- a/web/templates/new.html
+++ b/web/templates/new.html
@@ -49,7 +49,7 @@
             </div>
             <div class="form-group">
                 <label for="sub_area">Sub-area</label>
-                <input id="sub_area" name="sub_area" class="input" placeholder="e.g. proxmox, claude-memory">
+                <input id="sub_area" name="sub_area" class="input" placeholder="e.g. proxmox, magi">
             </div>
             <div class="form-group">
                 <label for="project">Project</label>


### PR DESCRIPTION
Platform-agnostic rebrand from claude-memory to MAGI.

**MAGI** — Multi-Agent Graph Intelligence

Universal memory server for any AI agent — not just Claude.

Changes:
- Go module path: `github.com/j33pguy/claude-memory` → `github.com/j33pguy/magi`
- Binary name: `claude-memory` → `magi`
- Env vars: `CLAUDE_MEMORY_*` → `MAGI_*`
- Config paths: `~/.claude/memory` → `~/.magi`
- 63 files, 279 insertions, 278 deletions

After merge, memory01 deployment needs:
- Update systemd service (ExecStart binary name, env vars)
- Update Ansible role name/vars
- Update OpenClaw memory-indexer plugin config