### PR TITLE
fix: SetTags transaction + REST dedup check

### DIFF
--- a/internal/api/remember.go
+++ b/internal/api/remember.go
@@ -48,6 +48,22 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Deduplication: check for near-duplicate before inserting
+	const maxDistance = 1.0 - 0.95 // cosine distance for 95% similarity
+	match, err := s.db.FindSimilar(embedding, maxDistance)
+	if err != nil {
+		s.logger.Warn("dedup check failed, proceeding with insert", "error", err)
+	} else if match != nil && match.Distance <= maxDistance {
+		s.logger.Info("deduplicated memory", "existing_id", match.Memory.ID, "distance", match.Distance)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"id":          match.Memory.ID,
+			"ok":          true,
+			"deduplicated": true,
+			"note":        fmt.Sprintf("existing memory %s is %.1f%% similar", match.Memory.ID, (1.0-match.Distance)*100),
+		})
+		return
+	}
+
 	speaker := req.Speaker
 	if speaker == "" {
 		speaker = "assistant"

--- a/internal/db/tag.go
+++ b/internal/db/tag.go
@@ -40,19 +40,24 @@ func (c *Client) GetTags(memoryID string) ([]string, error) {
 }
 
 // SetTags replaces all tags for a memory.
-// Uses a single batched multi-value INSERT instead of N individual statements
-// to minimize round-trips and reduce exposure to Turso Hrana stream expiry.
+// Wraps DELETE + INSERT in a transaction so both use the same Turso Hrana
+// stream, preventing expiry between the two operations.
 func (c *Client) SetTags(memoryID string, tags []string) error {
-	if _, err := c.DB.Exec("DELETE FROM memory_tags WHERE memory_id = ?", memoryID); err != nil {
+	tx, err := c.DB.Begin()
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.Exec("DELETE FROM memory_tags WHERE memory_id = ?", memoryID); err != nil {
 		return fmt.Errorf("clearing tags: %w", err)
 	}
 
 	if len(tags) == 0 {
-		return nil
+		return tx.Commit()
 	}
 
 	// Batch all tags into a single INSERT with multiple value tuples.
-	// This is one round-trip instead of N, avoiding stream expiry between statements.
 	placeholders := make([]string, len(tags))
 	args := make([]any, 0, len(tags)*2)
 	for i, tag := range tags {
@@ -61,9 +66,9 @@ func (c *Client) SetTags(memoryID string, tags []string) error {
 	}
 
 	query := fmt.Sprintf("INSERT INTO memory_tags (memory_id, tag) VALUES %s", strings.Join(placeholders, ", "))
-	if _, err := c.DB.Exec(query, args...); err != nil {
+	if _, err := tx.Exec(query, args...); err != nil {
 		return fmt.Errorf("inserting tags: %w", err)
 	}
 
-	return nil
+	return tx.Commit()
 }


### PR DESCRIPTION
## Changes

### Bug #56: SetTags fails due to Turso Hrana stream expiry
- Wraps the `DELETE` + `INSERT` in `SetTags()` in a single transaction
- Both operations now use the same Hrana stream, preventing expiry between statements
- Tags on memories created via REST `/remember` will now persist reliably

### Bug #57: REST /remember endpoint missing dedup check
- Ports the dedup logic from MCP `tools/remember.go` to `api/remember.go`
- After embedding generation, checks `FindSimilar()` with 0.05 max distance (95% similarity)
- Returns existing memory ID with `deduplicated: true` flag instead of inserting a duplicate
- Prevents cron jobs and API consumers from creating duplicate memories

**Build:** `go build ./...` ✅  
**Vet:** `go vet ./...` ✅

Closes #56, closes #57