### PR TITLE
fix: bump version to 0.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">AI agents shouldn't work in isolation. With MAGI, <strong>nothing important gets forgotten</strong>.</p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-v0.3.5-informational">
+  <img alt="Version" src="https://img.shields.io/badge/version-v0.3.6-informational">
   <img alt="License" src="https://img.shields.io/badge/License-ELv2-blue">
   <img alt="Self-Hosted" src="https://img.shields.io/badge/Self--Hosted-Yes-success">
   <img alt="Model Agnostic" src="https://img.shields.io/badge/Model--Agnostic-Yes-success">

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -108,8 +108,8 @@ func TestHandleHealth(t *testing.T) {
 	if resp["ok"] != true {
 		t.Errorf("ok = %v, want true", resp["ok"])
 	}
-	if resp["version"] != "0.3.5" {
-		t.Errorf("version = %v, want 0.3.5", resp["version"])
+	if resp["version"] != "0.3.6" {
+		t.Errorf("version = %v, want 0.3.6", resp["version"])
 	}
 	if resp["db_status"] != "ok" {
 		t.Errorf("db_status = %v, want ok", resp["db_status"])

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -8,7 +8,7 @@ import (
 )
 
 // version is the current MAGI version.
-const version = "0.3.5"
+const version = "0.3.6"
 
 // startTime records when the server started, used for uptime calculation.
 var startTime = time.Now()


### PR DESCRIPTION
Version bump for v0.3.6 release. Includes all changes from PRs #111-#122 (docs refresh, auth fix, gRPC task queue, magi-sync watch, TypeScript SDK, settings sync, test fix, artifact cleanup).