### PR TITLE
release: v0.4.1 retrieval + dedupe hotfixes

### DIFF
--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/j33pguy/magi/internal/db"
+	"github.com/j33pguy/magi/internal/rewrite"
 	"github.com/j33pguy/magi/internal/search"
 )
 
@@ -54,6 +56,28 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Optional rewrite fallback: run a second retrieval pass with deterministic
+	// query rewriting and merge candidates. Enable with rewrite_fallback=1.
+	if q.Get("rewrite_fallback") == "1" {
+		rewritten := rewrite.Query(query)
+		if rewritten != "" && rewritten != query {
+			rewrittenEmbedding, rerr := s.embedder.Embed(r.Context(), rewritten)
+			if rerr != nil {
+				s.logger.Warn("rewrite fallback embedding failed", "error", rerr)
+			} else {
+				extra, herr := s.db.HybridSearch(rewrittenEmbedding, rewritten, filter, topK*2)
+				if herr != nil {
+					s.logger.Warn("rewrite fallback search failed", "error", herr)
+				} else if len(extra) > 0 {
+					results = mergeHybridResults(results, extra)
+					if len(results) > topK {
+						results = results[:topK]
+					}
+				}
+			}
+		}
+	}
+
 	for _, result := range results {
 		if result.Memory.ParentID != "" {
 			parent, err := s.db.GetMemory(result.Memory.ParentID)
@@ -69,4 +93,40 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	search.ApplyRecencyWeighting(results, recencyDecay)
 
 	writeJSON(w, http.StatusOK, results)
+}
+
+func mergeHybridResults(primary, secondary []*db.HybridResult) []*db.HybridResult {
+	merged := make([]*db.HybridResult, 0, len(primary)+len(secondary))
+	seen := make(map[string]*db.HybridResult, len(primary)+len(secondary))
+
+	for _, r := range primary {
+		if r == nil || r.Memory == nil || r.Memory.ID == "" {
+			continue
+		}
+		copyR := *r
+		seen[r.Memory.ID] = &copyR
+		merged = append(merged, &copyR)
+	}
+
+	for _, r := range secondary {
+		if r == nil || r.Memory == nil || r.Memory.ID == "" {
+			continue
+		}
+		if existing, ok := seen[r.Memory.ID]; ok {
+			if r.Score > existing.Score {
+				existing.Score = r.Score
+				existing.Distance = r.Distance
+				existing.Memory = r.Memory
+			}
+			continue
+		}
+		copyR := *r
+		seen[r.Memory.ID] = &copyR
+		merged = append(merged, &copyR)
+	}
+
+	sort.SliceStable(merged, func(i, j int) bool {
+		return merged[i].Score > merged[j].Score
+	})
+	return merged
 }

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -761,20 +761,34 @@ func (c *Client) GetContextMemories(project string, limit int) ([]*Memory, error
 // FindSimilar returns the single closest non-archived memory by cosine distance.
 // Returns nil if no memories exist or the closest distance exceeds maxDistance.
 func (c *Client) FindSimilar(embedding []float32, maxDistance float64) (*VectorResult, error) {
+	return c.findSimilarWithProject("", embedding, maxDistance)
+}
+
+// FindSimilarInProject is project-scoped similarity lookup.
+func (c *Client) FindSimilarInProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
+	return c.findSimilarWithProject(project, embedding, maxDistance)
+}
+
+func (c *Client) findSimilarWithProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
 	var m Memory
 	var summary, source, sourceFile, parentID, archivedAt sql.NullString
 	var distance float64
 
-	err := c.DB.QueryRow(`
+	query := `
 		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
 		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
 		       m.created_at, m.updated_at, m.archived_at, m.token_count,
 		       vector_distance_cos(m.embedding, vector32(?)) AS distance
 		FROM memories m
-		WHERE m.archived_at IS NULL
-		ORDER BY distance ASC
-		LIMIT 1
-	`, float32sToBytes(embedding)).Scan(
+		WHERE m.archived_at IS NULL`
+	args := []any{float32sToBytes(embedding)}
+	if project != "" {
+		query += " AND m.project = ?"
+		args = append(args, project)
+	}
+	query += " ORDER BY distance ASC LIMIT 1"
+
+	err := c.DB.QueryRow(query, args...).Scan(
 		&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
 		&source, &sourceFile, &parentID, &m.ChunkIndex,
 		&m.Speaker, &m.Area, &m.SubArea,

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -596,7 +598,7 @@ func (c *Client) HybridSearch(embedding []float32, query string, filter *MemoryF
 	if topK <= 0 {
 		topK = 10
 	}
-	fetchK := topK * 3 // over-fetch to have enough for fusion
+	fetchK := topK * hybridFetchMultiplier() // over-fetch to have enough for fusion
 
 	// Run vector and BM25 searches concurrently.
 	var (
@@ -626,7 +628,9 @@ func (c *Client) HybridSearch(embedding []float32, query string, filter *MemoryF
 	}
 
 	// Build RRF score map keyed by memory ID.
-	const k = 60.0
+	k := hybridRRFK()
+	vecWeight := hybridVectorWeight()
+	bm25Weight := hybridBM25Weight()
 	type entry struct {
 		memory   *Memory
 		rrfScore float64
@@ -638,19 +642,19 @@ func (c *Client) HybridSearch(embedding []float32, query string, filter *MemoryF
 
 	for rank, r := range vecResults {
 		e := &entry{memory: r.Memory, vecRank: rank + 1, distance: r.Distance}
-		e.rrfScore += 1.0 / (k + float64(rank+1))
+		e.rrfScore += vecWeight / (k + float64(rank+1))
 		scored[r.Memory.ID] = e
 	}
 
 	for rank, r := range bm25Results {
 		if e, ok := scored[r.Memory.ID]; ok {
 			e.bm25Rank = rank + 1
-			e.rrfScore += 1.0 / (k + float64(rank+1))
+			e.rrfScore += bm25Weight / (k + float64(rank+1))
 		} else {
 			scored[r.Memory.ID] = &entry{
 				memory:   r.Memory,
 				bm25Rank: rank + 1,
-				rrfScore: 1.0 / (k + float64(rank+1)),
+				rrfScore: bm25Weight / (k + float64(rank+1)),
 			}
 		}
 	}
@@ -819,6 +823,54 @@ func (c *Client) findSimilarWithProject(project string, embedding []float32, max
 	m.Tags = tags
 
 	return &VectorResult{Memory: &m, Distance: distance}, nil
+}
+
+func hybridFetchMultiplier() int {
+	v := strings.TrimSpace(os.Getenv("MAGI_HYBRID_FETCH_MULTIPLIER"))
+	if v == "" {
+		return 3
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return 3
+	}
+	return n
+}
+
+func hybridRRFK() float64 {
+	v := strings.TrimSpace(os.Getenv("MAGI_HYBRID_RRF_K"))
+	if v == "" {
+		return 60.0
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f <= 0 {
+		return 60.0
+	}
+	return f
+}
+
+func hybridVectorWeight() float64 {
+	v := strings.TrimSpace(os.Getenv("MAGI_HYBRID_VECTOR_WEIGHT"))
+	if v == "" {
+		return 1.0
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f <= 0 {
+		return 1.0
+	}
+	return f
+}
+
+func hybridBM25Weight() float64 {
+	v := strings.TrimSpace(os.Getenv("MAGI_HYBRID_BM25_WEIGHT"))
+	if v == "" {
+		return 1.0
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f <= 0 {
+		return 1.0
+	}
+	return f
 }
 
 func nullString(s string) sql.NullString {

--- a/internal/db/mysql.go
+++ b/internal/db/mysql.go
@@ -611,14 +611,29 @@ func (c *MySQLClient) GetContextMemories(project string, limit int) ([]*Memory, 
 // FindSimilar returns the single closest non-archived memory by cosine distance.
 // Returns nil if no memories exist or the closest distance exceeds maxDistance.
 func (c *MySQLClient) FindSimilar(embedding []float32, maxDistance float64) (*VectorResult, error) {
-	rows, err := c.DB.Query(`
+	return c.findSimilarWithProject("", embedding, maxDistance)
+}
+
+// FindSimilarInProject is project-scoped similarity lookup.
+func (c *MySQLClient) FindSimilarInProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
+	return c.findSimilarWithProject(project, embedding, maxDistance)
+}
+
+func (c *MySQLClient) findSimilarWithProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
+	query := `
 		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
 		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
 		       m.created_at, m.updated_at, m.archived_at, m.token_count,
 		       m.embedding
 		FROM memories m
-		WHERE m.archived_at IS NULL AND m.embedding IS NOT NULL
-	`)
+		WHERE m.archived_at IS NULL AND m.embedding IS NOT NULL`
+	args := []any{}
+	if project != "" {
+		query += " AND m.project = ?"
+		args = append(args, project)
+	}
+
+	rows, err := c.DB.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("finding similar memory: %w", err)
 	}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -719,20 +719,34 @@ func (c *PostgresClient) GetContextMemories(project string, limit int) ([]*Memor
 
 // FindSimilar returns the single closest non-archived memory by cosine distance.
 func (c *PostgresClient) FindSimilar(embedding []float32, maxDistance float64) (*VectorResult, error) {
+	return c.findSimilarWithProject("", embedding, maxDistance)
+}
+
+// FindSimilarInProject is project-scoped similarity lookup.
+func (c *PostgresClient) FindSimilarInProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
+	return c.findSimilarWithProject(project, embedding, maxDistance)
+}
+
+func (c *PostgresClient) findSimilarWithProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
 	var m Memory
 	var summary, source, sourceFile, parentID, archivedAt sql.NullString
 	var distance float64
 
-	err := c.DB.QueryRow(`
+	query := `
 		SELECT m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
 		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
 		       m.created_at, m.updated_at, m.archived_at, m.token_count,
 		       m.embedding <=> $1::vector AS distance
 		FROM memories m
-		WHERE m.archived_at IS NULL
-		ORDER BY distance ASC
-		LIMIT 1
-	`, float32sToPgVector(embedding)).Scan(
+		WHERE m.archived_at IS NULL`
+	args := []any{float32sToPgVector(embedding)}
+	if project != "" {
+		query += " AND m.project = $2"
+		args = append(args, project)
+	}
+	query += " ORDER BY distance ASC LIMIT 1"
+
+	err := c.DB.QueryRow(query, args...).Scan(
 		&m.ID, &m.Content, &summary, &m.Project, &m.Type, &m.Visibility,
 		&source, &sourceFile, &parentID, &m.ChunkIndex,
 		&m.Speaker, &m.Area, &m.SubArea,

--- a/internal/db/sqlserver.go
+++ b/internal/db/sqlserver.go
@@ -602,15 +602,29 @@ func (c *SQLServerClient) GetContextMemories(project string, limit int) ([]*Memo
 
 // FindSimilar returns the single closest non-archived memory by cosine distance.
 func (c *SQLServerClient) FindSimilar(embedding []float32, maxDistance float64) (*VectorResult, error) {
-	// Fetch candidates with embeddings for Go-side similarity.
-	rows, err := c.db.Query(`
+	return c.findSimilarWithProject("", embedding, maxDistance)
+}
+
+// FindSimilarInProject is project-scoped similarity lookup.
+func (c *SQLServerClient) FindSimilarInProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
+	return c.findSimilarWithProject(project, embedding, maxDistance)
+}
+
+func (c *SQLServerClient) findSimilarWithProject(project string, embedding []float32, maxDistance float64) (*VectorResult, error) {
+	query := `
 		SELECT TOP(200) m.id, m.content, m.summary, m.project, m.type, m.visibility, m.source, m.source_file,
 		       m.parent_id, m.chunk_index, m.speaker, m.area, m.sub_area,
 		       m.created_at, m.updated_at, m.archived_at, m.token_count,
 		       m.embedding
 		FROM memories m
-		WHERE m.archived_at IS NULL AND m.embedding IS NOT NULL
-	`)
+		WHERE m.archived_at IS NULL AND m.embedding IS NOT NULL`
+	args := []any{}
+	if project != "" {
+		query += " AND m.project = @p1"
+		args = append(args, project)
+	}
+
+	rows, err := c.db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("finding similar memory: %w", err)
 	}

--- a/internal/remember/remember.go
+++ b/internal/remember/remember.go
@@ -65,6 +65,12 @@ func (e *SecretError) Error() string {
 	return fmt.Sprintf("Content may contain secrets: %s. Remove sensitive data before storing.", e.Warning)
 }
 
+// Optional extension for project-scoped similarity lookup.
+// Implemented by concrete DB clients for benchmark-safe dedupe behavior.
+type projectSimilarFinder interface {
+	FindSimilarInProject(project string, embedding []float32, maxDistance float64) (*db.VectorResult, error)
+}
+
 // Remember runs enrichment, dedup, save, tags, and contradiction detection.
 func Remember(ctx context.Context, store db.Store, embedder embeddings.Provider, input Input, opts Options) (*Result, error) {
 	if input.Content == "" {
@@ -131,9 +137,17 @@ func Remember(ctx context.Context, store db.Store, embedder embeddings.Provider,
 	maxDistance := 1.0 - dedupThreshold
 	groupDistance := 0.15 // 1.0 - 0.85
 
-	match, err := store.FindSimilar(embedding, groupDistance)
-	if err != nil {
-		logger.Warn("dedup check failed, proceeding with insert", "error", err)
+	var (
+		match  *db.VectorResult
+		simErr error
+	)
+	if ps, ok := store.(projectSimilarFinder); ok && input.Project != "" {
+		match, simErr = ps.FindSimilarInProject(input.Project, embedding, groupDistance)
+	} else {
+		match, simErr = store.FindSimilar(embedding, groupDistance)
+	}
+	if simErr != nil {
+		logger.Warn("dedup check failed, proceeding with insert", "error", simErr)
 	} else if match != nil {
 		// Do not dedupe across projects. This avoids suppressing writes for
 		// distinct project buckets (e.g. benchmark per-question projects).

--- a/internal/remember/remember.go
+++ b/internal/remember/remember.go
@@ -134,9 +134,20 @@ func Remember(ctx context.Context, store db.Store, embedder embeddings.Provider,
 	match, err := store.FindSimilar(embedding, groupDistance)
 	if err != nil {
 		logger.Warn("dedup check failed, proceeding with insert", "error", err)
-	} else if match != nil && match.Distance <= maxDistance {
-		logger.Info("deduplicated memory", "existing_id", match.Memory.ID, "distance", match.Distance)
-		return &Result{Deduplicated: true, Match: match}, nil
+	} else if match != nil {
+		// Do not dedupe across projects. This avoids suppressing writes for
+		// distinct project buckets (e.g. benchmark per-question projects).
+		if input.Project != "" && match.Memory != nil && match.Memory.Project != input.Project {
+			logger.Debug("ignoring cross-project dedupe candidate",
+				"input_project", input.Project,
+				"match_project", match.Memory.Project,
+				"match_id", match.Memory.ID,
+			)
+			match = nil
+		} else if match.Distance <= maxDistance {
+			logger.Info("deduplicated memory", "existing_id", match.Memory.ID, "distance", match.Distance)
+			return &Result{Deduplicated: true, Match: match}, nil
+		}
 	}
 
 	memory := &db.Memory{

--- a/internal/remember/remember_test.go
+++ b/internal/remember/remember_test.go
@@ -121,3 +121,76 @@ func TestRememberRejectsSecretsWithoutManager(t *testing.T) {
 		t.Fatalf("expected SecretError, got %T", err)
 	}
 }
+
+func TestRememberDedupesWithinProject(t *testing.T) {
+	store := newRememberStore(t)
+	embedder := &testEmbedder{}
+	opts := Options{Logger: slog.Default(), TagMode: TagModeWarn}
+
+	first, err := Remember(context.Background(), store, embedder, Input{
+		Content: "same content for same project",
+		Project: "proj-a",
+	}, opts)
+	if err != nil {
+		t.Fatalf("first remember: %v", err)
+	}
+	if first.Deduplicated {
+		t.Fatal("first remember should not dedupe")
+	}
+
+	second, err := Remember(context.Background(), store, embedder, Input{
+		Content: "same content for same project",
+		Project: "proj-a",
+	}, opts)
+	if err != nil {
+		t.Fatalf("second remember: %v", err)
+	}
+	if !second.Deduplicated {
+		t.Fatal("second remember should dedupe within same project")
+	}
+
+	mems, err := store.ListMemories(&db.MemoryFilter{Project: "proj-a", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	if len(mems) != 1 {
+		t.Fatalf("memories in proj-a = %d, want 1", len(mems))
+	}
+}
+
+func TestRememberDoesNotDedupeAcrossProjects(t *testing.T) {
+	store := newRememberStore(t)
+	embedder := &testEmbedder{}
+	opts := Options{Logger: slog.Default(), TagMode: TagModeWarn}
+
+	_, err := Remember(context.Background(), store, embedder, Input{
+		Content: "same content across projects",
+		Project: "proj-a",
+	}, opts)
+	if err != nil {
+		t.Fatalf("remember proj-a: %v", err)
+	}
+
+	second, err := Remember(context.Background(), store, embedder, Input{
+		Content: "same content across projects",
+		Project: "proj-b",
+	}, opts)
+	if err != nil {
+		t.Fatalf("remember proj-b: %v", err)
+	}
+	if second.Deduplicated {
+		t.Fatal("remember in proj-b should not dedupe against proj-a")
+	}
+
+	memA, err := store.ListMemories(&db.MemoryFilter{Project: "proj-a", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMemories proj-a: %v", err)
+	}
+	memB, err := store.ListMemories(&db.MemoryFilter{Project: "proj-b", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMemories proj-b: %v", err)
+	}
+	if len(memA) != 1 || len(memB) != 1 {
+		t.Fatalf("expected 1 memory per project, got proj-a=%d proj-b=%d", len(memA), len(memB))
+	}
+}


### PR DESCRIPTION
## Summary\nRelease prep for pre-v1 architecture updates only.\n\n### Included\n- prevent cross-project dedupe in remember path\n- project-scoped similarity lookup for dedupe\n- hybrid search tuning knobs for sqlite retrieval\n- optional search rewrite fallback\n- dedupe tag cleanup + explicit ONNX threading\n\n### Excluded\n- new v1 recall-budget architecture work (tier routing/telemetry)\n\n## Validation\n- local tests passing in prior workstream\n