### PR TITLE
docs: comprehensive documentation audit and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.4.1
+
+### Features
+- **Hybrid search tuning knobs** (#144) — configurable RRF constant, fetch multiplier, and vector/BM25 weights via `MAGI_HYBRID_RRF_K`, `MAGI_HYBRID_FETCH_MULTIPLIER`, `MAGI_HYBRID_VECTOR_WEIGHT`, `MAGI_HYBRID_BM25_WEIGHT`
+- **Search rewrite fallback** (#144) — optional `rewrite_fallback=1` parameter on `GET /search` re-runs the query with a deterministic rewrite when the first pass returns no results
+- **Project-scoped deduplication** (#144) — dedupe now respects project boundaries; same content in different projects creates separate memories
+
+### Fixes
+- **Cross-project dedupe prevention** (#144) — memories in different projects are no longer incorrectly deduplicated against each other
+- **Tag deduplication** — `normalizeTags` now removes duplicate tags before storage
+- **Explicit ONNX threading** — ONNX runtime thread counts configurable via `MAGI_ONNX_INTRA_THREADS`, `MAGI_ONNX_INTER_THREADS`, `MAGI_ONNX_EXECUTION_MODE`
+
+### Deps
+- Bump `onnxruntime_go` (#142)
+- Bump `actions/github-script` from 7 to 8 (#141)
+
 ## v0.4.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/j33pguy/magi/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/j33pguy/magi/actions/workflows/ci.yml/badge.svg"></a>
-  <img alt="Version" src="https://img.shields.io/badge/version-v0.4.0-informational">
+  <img alt="Version" src="https://img.shields.io/badge/version-v0.4.1-informational">
   <img alt="License" src="https://img.shields.io/badge/License-ELv2-blue">
   <img alt="Self-Hosted" src="https://img.shields.io/badge/Self--Hosted-Yes-success">
   <img alt="Model Agnostic" src="https://img.shields.io/badge/Model--Agnostic-Yes-success">

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -11,17 +11,13 @@ MAGI is the shared memory store. Every agent session (main, sub-agent, cron, Dis
 ## Connection
 
 ```
-MAGI_URL=http://10.5.5.45:8302
+MAGI_URL=http://localhost:8302
 ```
 
-Authentication requires an API token from Vault:
+Authentication requires an API token. Set via `MAGI_API_TOKEN` environment variable or retrieve from your secret backend:
 
 ```bash
-VAULT_TOKEN=$(curl -sk -X POST https://10.5.5.30:8200/v1/auth/approle/login \
-  -d '{"role_id":"<role_id>","secret_id":"<secret_id>"}' \
-  | jq -r '.auth.client_token')
-API_TOKEN=$(curl -sk -H "X-Vault-Token: $VAULT_TOKEN" \
-  https://10.5.5.30:8200/v1/homelab/data/claude_memory | jq -r '.data.data.api_token')
+API_TOKEN=$MAGI_API_TOKEN
 ```
 
 All requests need `Authorization: Bearer $API_TOKEN`.
@@ -29,7 +25,7 @@ All requests need `Authorization: Bearer $API_TOKEN`.
 ## Health Check (every session start)
 
 ```bash
-curl -s --max-time 3 http://10.5.5.45:8302/health
+curl -s --max-time 3 http://$MAGI_HOST:8302/health
 ```
 
 Expected: `{"ok":true, ...}`. If this fails, **stop and alert j33p**. Do not work without memory.
@@ -41,7 +37,7 @@ Expected: `{"ok":true, ...}`. If this fails, **stop and alert j33p**. Do not wor
 ### Remember (store knowledge)
 
 ```bash
-curl -s -X POST http://10.5.5.45:8302/remember \
+curl -s -X POST http://$MAGI_HOST:8302/remember \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -55,7 +51,7 @@ curl -s -X POST http://10.5.5.45:8302/remember \
 ### Recall (search knowledge)
 
 ```bash
-curl -s -X POST http://10.5.5.45:8302/recall \
+curl -s -X POST http://$MAGI_HOST:8302/recall \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query": "how to unseal vault", "limit": 5}'
@@ -64,7 +60,7 @@ curl -s -X POST http://10.5.5.45:8302/recall \
 ### Search conversations
 
 ```bash
-curl -s -X POST http://10.5.5.45:8302/conversations/search \
+curl -s -X POST http://$MAGI_HOST:8302/conversations/search \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query": "vault unsealing procedure", "limit": 10}'
@@ -73,7 +69,7 @@ curl -s -X POST http://10.5.5.45:8302/conversations/search \
 ### Delete (remove noise/duplicates)
 
 ```bash
-curl -s -X DELETE "http://10.5.5.45:8302/memories/<id>" \
+curl -s -X DELETE "http://$MAGI_HOST:8302/memories/<id>" \
   -H "Authorization: Bearer $API_TOKEN"
 ```
 
@@ -85,13 +81,13 @@ Use the correct `type` when storing memories. If omitted, MAGI auto-classifies b
 
 | Type | Use For | Example |
 |------|---------|---------|
-| `memory` | General facts, state, context | "pihole-01 is at 10.5.5.11 on VLAN 5" |
+| `memory` | General facts, state, context | "pihole-01 is the primary DNS server on VLAN 5" |
 | `procedure` | How-to guides, runbooks, step-by-step | "How to deploy Traefik: step 1..." |
 | `decision` | Choices made and why | "Decided to use gRPC over REST for all internal services" |
 | `incident` | Outages, failures, postmortems | "Vault outage caused by missing firewall zone ID" |
 | `task` | Work items, tracking | "[QUEUED] Fix privacy filter" |
 | `conversation` | Session summaries | "Discussed VLAN migration and DNS changes" |
-| `state` | Current infrastructure state | "pve-01 is at 10.5.75.30 with 120GB RAM" |
+| `state` | Current infrastructure state | "pve-01 has 120GB RAM, running Proxmox 8.2" |
 
 ### Auto-classification
 
@@ -107,59 +103,48 @@ You can always override by setting `type` explicitly.
 
 ## Work Tracking
 
-Every task j33p requests gets tracked through MAGI:
+MAGI has a dedicated task queue for tracking work. Use the task API (or MCP tools `create_task`, `update_task`, `list_tasks`, `add_task_event`) instead of embedding status markers in memory content.
 
-### Lifecycle
+### Task Lifecycle
 
 ```
-[QUEUED] → [RUNNING] → [DONE]
-                     → [BLOCKED]
+queued → started → done
+                 → failed
+                 → blocked
+                 → canceled
 ```
 
-### Queue a task
+### Create a task
 ```bash
-curl -s -X POST http://10.5.5.45:8302/remember \
+curl -s -X POST http://$MAGI_HOST:8302/task \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": "[QUEUED] Deploy new Traefik config with wildcard cert",
-    "type": "task",
-    "tags": ["work-tracking", "active", "traefik"],
-    "source": "discord"
+    "title": "Deploy new Traefik config with wildcard cert",
+    "project": "infrastructure",
+    "priority": "high",
+    "status": "queued"
   }'
 ```
 
-### Update status
+### Update task status
 ```bash
-curl -s -X POST http://10.5.5.45:8302/remember \
+curl -s -X PATCH http://$MAGI_HOST:8302/task/<id> \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": "[RUNNING] Deploy new Traefik config — branch feat/wildcard-cert, agent: dinesh",
-    "type": "task",
-    "tags": ["work-tracking", "active", "traefik"]
+    "status": "done",
+    "status_comment": "PR #42 merged, verified on all routes"
   }'
 ```
 
-### Complete
+### List active tasks
 ```bash
-curl -s -X POST http://10.5.5.45:8302/remember \
-  -H "Authorization: Bearer $API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "content": "[DONE] Traefik wildcard cert deployed — PR #42 merged, verified on all routes",
-    "type": "task",
-    "tags": ["work-tracking", "traefik"]
-  }'
+curl -s "http://$MAGI_HOST:8302/task?status=queued&status=started" \
+  -H "Authorization: Bearer $API_TOKEN"
 ```
 
-### Check active work before starting
-```bash
-curl -s -X POST http://10.5.5.45:8302/conversations/search \
-  -H "Authorization: Bearer $API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "work-tracking active queued running", "limit": 10}'
-```
+See `task-queue.md` for the full task model, event types, and MCP tool reference.
 
 ---
 
@@ -233,7 +218,7 @@ detects a git remote, and can be set manually when indexing project state:
 
 ```json
 {
-  "content": "MAGI v0.3.10 — Universal memory server for AI agents.",
+  "content": "MAGI — Universal memory server for AI agents.",
   "type": "state",
   "tags": ["ghrepo:j33pguy/magi", "project", "inventory"],
   "project": "magi"
@@ -273,7 +258,7 @@ If your agent supports MCP (Model Context Protocol), MAGI exposes tools directly
 - `index_turn` — Index a conversation turn
 - `index_session` — Index a full session summary
 
-MCP server runs on port 8301 (gRPC) or via stdio. See `docs/mcp.md` for setup.
+MCP server runs on port 8301 (gRPC) or via stdio. See `docs/mcp-tools.md` for setup.
 
 ---
 
@@ -282,7 +267,7 @@ MCP server runs on port 8301 (gRPC) or via stdio. See `docs/mcp.md` for setup.
 ### Store a procedure
 ```json
 {
-  "content": "How to restart MAGI on magi01:\n1. SSH: ssh ansible@10.5.5.45\n2. Pull latest: cd /opt/magi/src && sudo git pull\n3. Build: sudo go build -o ../bin/magi .\n4. Restart: sudo systemctl restart magi\n5. Verify: curl -s http://10.5.5.45:8302/health",
+  "content": "How to restart MAGI:\n1. Pull latest: cd /opt/magi/src && sudo git pull\n2. Build: sudo go build -o ../bin/magi .\n3. Restart: sudo systemctl restart magi\n4. Verify: curl -s http://localhost:8302/health",
   "type": "procedure",
   "tags": ["magi", "infrastructure", "runbook"],
   "source": "discord"

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ MAGI is model- and agent-agnostic, self-hosted, and has zero cloud dependency by
 **Getting Started**
 - `onboarding.md`
 - `agent-project-memory.md`
+- `AGENT-GUIDE.md` — practical guide for AI agents using MAGI
 
 **APIs And Tools**
 - `mcp-tools.md` — 24 MCP tools reference

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -40,7 +40,7 @@ Admin-only endpoints on the legacy HTTP API:
 - `GET /auth/machines` — list all machine credentials
 - `POST /auth/machines/{id}/revoke` — revoke a machine credential
 
-## Self-Enrollment (v0.3.10+)
+## Self-Enrollment (v0.4.0+)
 
 For onboarding machines without sharing the admin API token, use enrollment tokens:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,6 +67,13 @@ These are the most commonly used environment variables. All values here are real
 | `ONNXRUNTIME_LIB` | empty | Override ONNX Runtime shared library path |
 | `MAGI_TURBOQUANT_ENABLED` | empty | Enable TurboQuant (if available) |
 | `MAGI_TURBOQUANT_BITS` | empty | TurboQuant bit depth |
+| `MAGI_HYBRID_FETCH_MULTIPLIER` | `3` | Over-fetch factor for hybrid search (topK * multiplier) |
+| `MAGI_HYBRID_RRF_K` | `60.0` | Reciprocal Rank Fusion constant K |
+| `MAGI_HYBRID_VECTOR_WEIGHT` | `1.0` | Vector search weight in RRF fusion |
+| `MAGI_HYBRID_BM25_WEIGHT` | `1.0` | BM25 search weight in RRF fusion |
+| `MAGI_ONNX_INTRA_THREADS` | `1` | ONNX intra-op thread count |
+| `MAGI_ONNX_INTER_THREADS` | `1` | ONNX inter-op thread count |
+| `MAGI_ONNX_EXECUTION_MODE` | `sequential` | ONNX execution mode (`parallel` or `sequential`) |
 
 ## Auth And Secrets
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -245,6 +245,7 @@ GET /memory/search?q=example
 | `tags` | no | Comma-separated tag filter |
 | `project` | no | Project filter |
 | `type` | no | Type filter |
+| `rewrite_fallback` | no | Set to `1` to re-run query with a deterministic rewrite when the first pass returns no results |
 
 ---
 
@@ -371,6 +372,37 @@ POST /auth/machines/{id}/revoke
 ```
 
 Admin-only endpoints that manage machine credentials.
+
+---
+
+### Self-Enrollment
+
+```
+POST /auth/enrollment-tokens
+GET /auth/enrollment-tokens
+POST /auth/enrollment-tokens/{id}/revoke
+POST /auth/enroll
+```
+
+`POST /auth/enrollment-tokens` (admin-only) creates a limited-use token that machines can exchange for a permanent credential. `POST /auth/enroll` requires no Authorization header — the enrollment token is passed in the request body.
+
+See `auth-architecture.md` for details.
+
+---
+
+### Behavioral Patterns
+
+```
+GET /patterns
+```
+
+Query params: `project`, `type`, `tags`, `limit`, `offset`, `speaker`, `area`, `sub_area`, `after`, `before`, `trend`, `pattern_area`, `source`, `max_patterns`.
+
+```
+GET /patterns/trending
+```
+
+Same query params as `/patterns`, plus `include_stable`. Returns patterns where `trend != stable`.
 
 ---
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -53,7 +53,7 @@ Store a memory with automatic semantic embedding, deduplication, and contradicti
 |-----------|------|----------|-------------|
 | `content` | string | yes | The content to remember |
 | `project` | string | yes* | Project/namespace name (required unless the server detected a default project) |
-| `type` | string | no | Memory type: `memory`, `incident`, `lesson`, `decision`, `project_context`, `conversation`, `audit`, `runbook`, `preference`, `context`, `security`, `state` |
+| `type` | string | no | Memory type: `memory`, `incident`, `lesson`, `decision`, `project_context`, `conversation`, `audit`, `runbook`, `preference`, `context`, `security`, `state`, `procedure` |
 | `summary` | string | no | Brief one-line summary |
 | `tags` | string[] | no | Tags for categorization |
 | `dedup_threshold` | number | no | Similarity threshold for deduplication (0.0–1.0, default 0.95) |
@@ -97,7 +97,7 @@ Browse and filter memories without semantic search.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `project` | string | no | Filter by project |
-| `type` | string | no | Memory type: `memory`, `incident`, `lesson`, `decision`, `project_context`, `conversation`, `audit`, `runbook`, `preference`, `context`, `security` |
+| `type` | string | no | Memory type: `memory`, `incident`, `lesson`, `decision`, `project_context`, `conversation`, `audit`, `runbook`, `preference`, `context`, `security`, `state`, `procedure` |
 | `tags` | string[] | no | Filter by tags |
 | `limit` | number | no | Max results (default 20) |
 | `offset` | number | no | Pagination offset (default 0) |
@@ -116,7 +116,7 @@ Update an existing memory. Re-embeds automatically if content changes.
 | `id` | string | yes | Memory ID |
 | `content` | string | no | New content (triggers re-embedding) |
 | `summary` | string | no | New summary |
-| `type` | string | no | Memory type: `memory`, `incident`, `lesson`, `decision`, `project_context`, `conversation`, `audit`, `runbook`, `preference`, `context`, `security` |
+| `type` | string | no | Memory type: `memory`, `incident`, `lesson`, `decision`, `project_context`, `conversation`, `audit`, `runbook`, `preference`, `context`, `security`, `state`, `procedure` |
 | `tags` | string[] | no | Replace all tags with these |
 
 ---

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -22,3 +22,13 @@ var results = await magi.RecallAsync(new() { Query = "API changes", Limit = 5 })
 foreach (var r in results.Results)
     Console.WriteLine($"{r.Score:F2} — {r.Memory.Content}");
 ```
+
+## Available Methods
+
+| Method | Description |
+|--------|-------------|
+| `RememberAsync(RememberRequest)` | Store a memory |
+| `RecallAsync(RecallRequest)` | Semantic search for memories |
+| `ListAsync(Dictionary<string, string>?)` | List and filter memories |
+| `ForgetAsync(string id)` | Archive (soft-delete) a memory |
+| `HealthAsync()` | Check server health |


### PR DESCRIPTION
## Summary

- Add missing CHANGELOG v0.4.1 entry covering hybrid search tuning, project-scoped dedupe, rewrite fallback, ONNX threading, and tag dedup
- Add missing endpoints to http-api.md: self-enrollment token flow (`/auth/enrollment-tokens`, `/auth/enroll`) and behavioral patterns (`/patterns`, `/patterns/trending`)
- Add `rewrite_fallback` search parameter to http-api.md
- Add 7 new env vars to deployment.md: hybrid search tuning (`MAGI_HYBRID_*`) and ONNX threading (`MAGI_ONNX_*`)
- Fix AGENT-GUIDE.md: genericize all hardcoded private IPs, fix broken `docs/mcp.md` link (now `docs/mcp-tools.md`), replace legacy `[QUEUED]/[RUNNING]/[DONE]` work tracking with dedicated task queue API
- Fix README version badge v0.4.0 → v0.4.1
- Fix auth-architecture.md self-enrollment version label v0.3.10 → v0.4.0
- Align memory type enumerations in mcp-tools.md: add `procedure` and `state` to `remember`, `list_memories`, `update_memory`
- Add AGENT-GUIDE.md to docs/README.md index
- Document all .NET SDK methods (`ListAsync`, `ForgetAsync`, `HealthAsync`) in sdks/dotnet/README.md

## Test plan

- [ ] Verify all internal doc links resolve correctly
- [ ] Confirm env var names match code (`os.Getenv` calls)
- [ ] Confirm endpoint paths match server router registrations
- [ ] Spot-check type enumerations against MCP tool definitions in `internal/tools/`

🤖 Generated with [Claude Code](https://claude.ai/code)